### PR TITLE
Use nodejs 10 build slave by default

### DIFF
--- a/fe-ionic/Jenkinsfile.template
+++ b/fe-ionic/Jenkinsfile.template
@@ -22,7 +22,7 @@ library identifier: 'ods-library@production', retriever: modernSCM(
   https://github.com/opendevstack/ods-project-quickstarters/tree/master/jenkins-slaves/nodejs8-angular
  */
 odsPipeline(
-  image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular",
+  image: "${dockerRegistry}/cd/jenkins-slave-nodejs10-angular",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [


### PR DESCRIPTION
After testing today the move to NodeJS 10 build slave worked fine, so I would make it a default for the next release