### PR TITLE
Use Node 10 for bulid and deployment environment for be-typescript-express qs

### DIFF
--- a/be-typescript-express/Jenkinsfile.template
+++ b/be-typescript-express/Jenkinsfile.template
@@ -22,7 +22,7 @@ library identifier: 'ods-library@production', retriever: modernSCM(
   https://github.com/opendevstack/ods-quickstarters/tree/master/common/jenkins-slaves/nodejs8-angular
  */
 odsPipeline(
-  image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular",
+  image: "${dockerRegistry}/cd/jenkins-slave-nodejs10-angular",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [

--- a/be-typescript-express/files/docker/Dockerfile
+++ b/be-typescript-express/files/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-alpine
+FROM node:10-alpine
 
 COPY dist /node
 

--- a/be-typescript-express/fix/index.ts
+++ b/be-typescript-express/fix/index.ts
@@ -1,9 +1,9 @@
-export * from "./greeter";
-import * as express from "express";
-import {Application} from "express";
+
 import bodyParser = require("body-parser");
 import weatherRouter from "./routes/weather";
-const app: Application = express();
+export * from "./greeter";
+import * as express from "express";
+const app: express.Application = express();
 
 app.use(bodyParser.json({type: "application/json"}));
 
@@ -13,5 +13,6 @@ app.use("/api/weather", weatherRouter);
 // initialize the webserver
 const port = process.env.PORT || "8080";
 app.listen(port, () => {
+    // tslint:disable-next-line:no-console
     console.info(`App listening on port ${port}!`);
 });


### PR DESCRIPTION
Deployment image doesn't match build image & Linting error fix for be-typescript-express quick starter. 
Fixing #8 