### PR TITLE
Add central Tailorfile to easily compare resources

### DIFF
--- a/Tailorfile
+++ b/Tailorfile
@@ -1,0 +1,7 @@
+context-dir common/jenkins-slaves/airflow/ocp-config
+context-dir common/jenkins-slaves/golang/ocp-config
+context-dir common/jenkins-slaves/maven/ocp-config
+context-dir common/jenkins-slaves/nodejs8-angular/ocp-config
+context-dir common/jenkins-slaves/nodejs10-angular/ocp-config
+context-dir common/jenkins-slaves/python/ocp-config
+context-dir common/jenkins-slaves/scala/ocp-config


### PR DESCRIPTION
Allows to easily run `tailor status` in the root of the repo to get an overview of the current drift. This requires Tailor 0.10.4 (released today).

Once this is in, I can update `ods-core` with the latest required Tailor version and cleanup the install scripts to use this central file.