### PR TITLE
Remove dependency on ods-quickstarters.env file

### DIFF
--- a/common/jenkins-slaves/airflow/ocp-config/Tailorfile
+++ b/common/jenkins-slaves/airflow/ocp-config/Tailorfile
@@ -1,6 +1,5 @@
 namespace cd
 selector app=jenkins-slave-airflow
 param-file ../../../../../ods-configuration/ods-core.env
-param-file ../../../../../ods-configuration/ods-quickstarters.env
 ignore-unknown-parameters true
 bc,is

--- a/common/jenkins-slaves/golang/ocp-config/Tailorfile
+++ b/common/jenkins-slaves/golang/ocp-config/Tailorfile
@@ -1,6 +1,5 @@
 namespace cd
 selector app=jenkins-slave-golang
 param-file ../../../../../ods-configuration/ods-core.env
-param-file ../../../../../ods-configuration/ods-quickstarters.env
 ignore-unknown-parameters true
 bc,is

--- a/common/jenkins-slaves/maven/ocp-config/Tailorfile
+++ b/common/jenkins-slaves/maven/ocp-config/Tailorfile
@@ -1,6 +1,5 @@
 namespace cd
 selector app=jenkins-slave-maven
 param-file ../../../../../ods-configuration/ods-core.env
-param-file ../../../../../ods-configuration/ods-quickstarters.env
 ignore-unknown-parameters true
 bc,is

--- a/common/jenkins-slaves/nodejs10-angular/ocp-config/Tailorfile
+++ b/common/jenkins-slaves/nodejs10-angular/ocp-config/Tailorfile
@@ -1,6 +1,5 @@
 namespace cd
 selector app=jenkins-slave-nodejs10-angular
 param-file ../../../../../ods-configuration/ods-core.env
-param-file ../../../../../ods-configuration/ods-quickstarters.env
 ignore-unknown-parameters true
 bc,is

--- a/common/jenkins-slaves/python/ocp-config/Tailorfile
+++ b/common/jenkins-slaves/python/ocp-config/Tailorfile
@@ -1,6 +1,5 @@
 namespace cd
 selector app=jenkins-slave-python
 param-file ../../../../../ods-configuration/ods-core.env
-param-file ../../../../../ods-configuration/ods-quickstarters.env
 ignore-unknown-parameters true
 bc,is

--- a/common/jenkins-slaves/scala/ocp-config/Tailorfile
+++ b/common/jenkins-slaves/scala/ocp-config/Tailorfile
@@ -1,6 +1,5 @@
 namespace cd
 selector app=jenkins-slave-scala
 param-file ../../../../../ods-configuration/ods-core.env
-param-file ../../../../../ods-configuration/ods-quickstarters.env
 ignore-unknown-parameters true
 bc,is


### PR DESCRIPTION
Content of that file right now is https://github.com/opendevstack/ods-core/blob/master/configuration-sample/ods-quickstarters.env.sample. The r-shiny stuff is not needed anymore, right @gerardcl? And the release-manager config will be done differently, see #34.