### PR TITLE
Update and improve docker-plain quickstarter docs

### DIFF
--- a/docker-plain/Jenkinsfile.template
+++ b/docker-plain/Jenkinsfile.template
@@ -43,7 +43,7 @@ odsPipeline(
 
 def stageBuild(def context) {
   stage('Build') {
-    // copy any other artifacts if needed
+    // copy any other artifacts, if needed
     // sh "cp -r build docker/dist"
     // the docker context passed in /docker
   }
@@ -51,7 +51,7 @@ def stageBuild(def context) {
 
 def stageUnitTest(def context) {
   stage('Unit Test') {
-    // if needed add your unit tests here
+    // add your unit tests here, if needed
   }
 }
 

--- a/docker-plain/README.md
+++ b/docker-plain/README.md
@@ -3,13 +3,3 @@
 Documentation is located in our [official documentation](https://www.opendevstack.org/ods-documentation/ods-quickstarters/latest/index.html)
 
 Please update documentation in the [antora page directory](https://github.com/opendevstack/ods-quickstarters/tree/master/docs/modules/ROOT/pages)
-
-## Release Manager compatibility
-
-Being generic, this component does not produce any test results, which are currently required for a component to be successfully orchestrated by the *Release Manager*. That said, if you develop your application component based on this quickstarter, please make sure that test results are provided accordingly:
-
-1) Your component has to place its test results in the xUnit XML format in the `build/test-results/test` directory. Make sure that no other `.xml` files are contained therein.
-
-2) Your component has to provide these test results to the [Jenkins JUnit plugin](https://plugins.jenkins.io/junit) via its `junit` step function.
-
-Please feel free to consult our existing quickstarters. An example can be found in the `be-springboot` quickstarter's [Jenkinsfile](https://github.com/opendevstack/ods-quickstarters/blob/master/boilerplates/be-springboot/Jenkinsfile).

--- a/docs/modules/ROOT/pages/docker-plain.adoc
+++ b/docs/modules/ROOT/pages/docker-plain.adoc
@@ -2,9 +2,9 @@
 
 == Purpose of this quickstarter
 
-Use this quickstarter when you want to start from a plain dockerfile only - w/o a framework on top.
-A good usecase here is a dockerfile you found on github that you want to run with OpenDevStack features,
-or that you need to "openshiftify", by setting an execution user or alike.
+Use this quickstarter when you want to start from a plain Dockerfile only, without any framework on top.
+A good usecase here is a Dockerfile you found on GitHub which you want to run with OpenDevStack features,
+or that you need to "OpenShiftify", by setting an (non-root) execution user, etc.
 
 == What files / architecture is generated?
 
@@ -18,32 +18,43 @@ or that you need to "openshiftify", by setting an execution user or alike.
 
 == Frameworks used
 
-None, except the ODS https://github.com/opendevstack/ods-jenkins-shared-library[jenkins shared library]
+None, except for the ODS https://github.com/opendevstack/ods-jenkins-shared-library[jenkins shared library].
 
 == Usage - how do you start after you provisioned this quickstarter
 
 Amend the generated `Dockerfile` as needed.
 
-== How this quickstarter is built through jenkins
+== How this quickstarter is built through Jenkins
 
-The shared library is used as is - whatever is in the `/docker` folder is passed to `oc start build` as docker context.
-In case you want to run testing, plug into `stageUnitTest`.
+Whatever is in the `/docker` folder will be passed to `oc start build` as the docker context. You can add other files to that context as needed:
 
 ----
 def stageBuild(def context) {
   stage('Build') {
-    // copy any other artifacts if needed
+    // copy any other artifacts, if needed
     // sh "cp -r build docker/dist"
     // the docker context passed in /docker
   }
 }
+----
 
+In case you want to run unit tests, you can add a corresponding statement to `stageUnitTest`:
+
+----
 def stageUnitTest(def context) {
   stage('Unit Test') {
-    // if needed add your unit tests here
+    // add your unit tests here, if needed
   }
 }
 ----
+
+Assuming your component contains source code you want to have delivered by the _Release Manager_, the execution of tests and the reporting of their results is mandatory. For this, your component will have to...
+
+- place the test results in the xUnit XML format in a path known to `context.testResults` (defaults to `build/test-results/test`)
+
+- provide these test results to the link:https://plugins.jenkins.io/junit[Jenkins JUnit plugin] via its `junit` step function.
+
+Feel free to look out for examples in our existing quickstarters, such as link:https://github.com/opendevstack/ods-quickstarters/blob/master/be-java-springboot/Jenkinsfile.template[be-java-springboot].
 
 == Builder Slave used
 


### PR DESCRIPTION
Updates and improves the documentation on the `docker-plain` quickstarter:

- simplified existing Antora docs
- added Release Manager specific requirements to the Antora docs