### PR TITLE
Adding the possibility to import certificates from trusted sources and disabling checks using airflow confusion

### DIFF
--- a/airflow-cluster/base-images/airflow/Dockerfile
+++ b/airflow-cluster/base-images/airflow/Dockerfile
@@ -115,7 +115,9 @@ RUN pip install ${HOME}/oauth \
     && mkdir -p /var/log/filebeat \
     && chgrp -R 0 /var/log/filebeat  \
     && chmod -R g=u /var/log/filebeat  \
-    && chmod g+r /etc/filebeat/filebeat.yml
+    && chmod g+r /etc/filebeat/filebeat.yml \
+    && chgrp -R 0 /etc/pki/ca-trust \
+    && chmod -R g=u /etc/pki/ca-trust
 
 RUN if [ -n "${PYTHON_DEPS}" ]; then \
         if [[ ! -z ${NEXUS_URL} ]]; \

--- a/airflow-cluster/base-images/airflow/README.md
+++ b/airflow-cluster/base-images/airflow/README.md
@@ -111,6 +111,7 @@ and Secrets. They are:
 | Name | Type | Description|
 |-----|------|------------|
 |**AIRFLOW_COMMAND**| String (Required) | Airflow command that should be executed or empty for a custom commands. It will define if the container will behave as the webserver, schediler and so on.  The availabled options are: 'webserver', 'worker', 'scheduler', 'flower' or 'version' |
+|AIRFLOW_HOSTS_TO_TRUST| String (Required) | A semi-colon separeted list of hosts to be trusted in the format <hostname1>:<port1>;<hostname2>:<port2>;... . This host will have their certificate chain automaticaly trusted |
 |POSTGRES_HOST| String (Required) | Postgresql host to which Airflow should connect |
 |POSTGRES_PORT|String| Postgresql port to which Airflow should connect. Default: 5432 |
 |POSTGRES_USER|String (Required) | Postgresql username which Airflow should use |

--- a/airflow-cluster/base-images/airflow/README.md
+++ b/airflow-cluster/base-images/airflow/README.md
@@ -111,7 +111,7 @@ and Secrets. They are:
 | Name | Type | Description|
 |-----|------|------------|
 |**AIRFLOW_COMMAND**| String (Required) | Airflow command that should be executed or empty for a custom commands. It will define if the container will behave as the webserver, schediler and so on.  The availabled options are: 'webserver', 'worker', 'scheduler', 'flower' or 'version' |
-|AIRFLOW_HOSTS_TO_TRUST| String (Required) | A semi-colon separeted list of hosts to be trusted in the format <hostname1>:<port1>;<hostname2>:<port2>;... . This host will have their certificate chain automaticaly trusted |
+|AIRFLOW_HOSTS_TO_TRUST| String (Required) | A semi-colon separeted list of hosts to be trusted in the format `hostname1:port1;hostname2:port2;...` . This host will have their certificate chain automaticaly trusted |
 |POSTGRES_HOST| String (Required) | Postgresql host to which Airflow should connect |
 |POSTGRES_PORT|String| Postgresql port to which Airflow should connect. Default: 5432 |
 |POSTGRES_USER|String (Required) | Postgresql username which Airflow should use |

--- a/airflow-cluster/base-images/airflow/README.md
+++ b/airflow-cluster/base-images/airflow/README.md
@@ -85,8 +85,8 @@ email_key = metadata.name
 oauth_permission_backend=airflow_oauth.contrib.auth.backends.openshift_permission_backend
 ```
 
-NOTE: if SSL verification fails when calling oauth callback, users can load known CA or set
-environment variable `PYTHONHTTPSVERIFY` to `0`.
+NOTE: if SSL verification fails when calling oauth callback, users can import the host certificate chain using `AIRFLOW_HOSTS_TO_TRUST` or set
+environment variable `AIRFLOW__HTTP_CLIENT__INSECURE` to `true`.
 
 ### OpenShift Plugin Settings
 

--- a/airflow-cluster/base-images/airflow/README.md
+++ b/airflow-cluster/base-images/airflow/README.md
@@ -111,7 +111,7 @@ and Secrets. They are:
 | Name | Type | Description|
 |-----|------|------------|
 |**AIRFLOW_COMMAND**| String (Required) | Airflow command that should be executed or empty for a custom commands. It will define if the container will behave as the webserver, schediler and so on.  The availabled options are: 'webserver', 'worker', 'scheduler', 'flower' or 'version' |
-|AIRFLOW_HOSTS_TO_TRUST| String (Required) | A semi-colon separeted list of hosts to be trusted in the format `hostname1:port1;hostname2:port2;...` . This host will have their certificate chain automaticaly trusted |
+|AIRFLOW_HOSTS_TO_TRUST| String | A semi-colon separeted list of hosts to be trusted in the format `hostname1:port1;hostname2:port2;...` . This host will have their certificate chain automaticaly trusted |
 |POSTGRES_HOST| String (Required) | Postgresql host to which Airflow should connect |
 |POSTGRES_PORT|String| Postgresql port to which Airflow should connect. Default: 5432 |
 |POSTGRES_USER|String (Required) | Postgresql username which Airflow should use |

--- a/airflow-cluster/base-images/airflow/config/airflow.cfg
+++ b/airflow-cluster/base-images/airflow/config/airflow.cfg
@@ -690,3 +690,8 @@ access_roles=admin,edit
 superuser_roles=admin
 # Base OpenShift console url for build the links to airflow resources
 openshift_console_url=https://localhost
+
+# Global http client configuration
+[http_client]
+# Insecure allows insecure HTTPS connection, such as when using a self-signed certificate
+insecure=false

--- a/airflow-cluster/base-images/airflow/dist/oauth/airflow_oauth/contrib/auth/backends/generic_oauth.py
+++ b/airflow-cluster/base-images/airflow/dist/oauth/airflow_oauth/contrib/auth/backends/generic_oauth.py
@@ -29,15 +29,16 @@ from flask_oauthlib.client import OAuth
 from airflow import models, configuration
 from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
-import os, ssl
-
-if (os.environ.get('PYTHONHTTPSVERIFY', '') is '0' and
-    getattr(ssl, '_create_unverified_context', None)):
-    ssl._create_default_https_context = ssl._create_unverified_context
-
+import ssl
 
 log = LoggingMixin().log
 
+if configuration.conf.has_section("http_client") \
+        and configuration.conf.has_option("http_client", "insecure") \
+        and configuration.conf.getboolean("http_client", "insecure") \
+        and getattr(ssl, '_create_unverified_context', None):
+    ssl._create_default_https_context = ssl._create_unverified_context
+    log.warn("Airflow is using an insecure HTTP client. ROOT CA check is disabled.")
 
 def get_config_param(param):
     return str(configuration.conf.get('oauth', param))


### PR DESCRIPTION
Fixing the SSL problem if the OAuth host is not in the certificate bundle.

For this PR there are to changes:
1. Improvement on how to disable the certificate check using airflow configuration options
2. Import the certificates by providing the host name using an environment variable