### PR TITLE
prevent error Duplicate nav

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: ods-quickstarters
 title: ODS Quickstarters
-version: 2.0
+version: latest
 nav: 
 - modules/ROOT/nav.adoc
 


### PR DESCRIPTION
set version to latest to prevent error 'error: Duplicate nav: 2@ods-quickstarters:ROOT:nav.adoc'

Build of _ods-documentation_ failed with this error. See https://travis-ci.org/opendevstack/ods-documentation/builds/643439835?utm_medium=notification&utm_source=github_status