### PR TITLE
Add test-logger plugin for e2e-spock-geb

### DIFF
--- a/e2e-spock-geb/files/build.gradle
+++ b/e2e-spock-geb/files/build.gradle
@@ -21,6 +21,7 @@ buildscript {
 plugins {
   id 'java'
   id 'groovy'
+  id 'com.adarshr.test-logger' version "2.0.0"
 }
 
 repositories {
@@ -181,3 +182,6 @@ test {
     tasks.findByName(generateTaskName(TestExecutionPhases.INSTALLATION, TestLanguages.GROOVY)).mustRunAfter generateTaskName(TestExecutionPhases.INSTALLATION, TestLanguages.JAVA)
 }
 
+testlogger {
+    showStandardStreams true
+}


### PR DESCRIPTION
Adds the com.adarshr.test-logger Gradle plugin for improved logging. Also, enables logging of STDOUT/STDERR streams.