### PR TITLE
Add OS project and cluster public host to env for e2e-spock-geb

### DIFF
--- a/e2e-spock-geb/Jenkinsfile.template
+++ b/e2e-spock-geb/Jenkinsfile.template
@@ -42,8 +42,14 @@ def stageTest(def context) {
     springBootEnv = 'dev'
   }
 
+  def openShiftPublicHost
+  node {
+    def stableUrl = env.SONAR_SERVER_URL
+    openShiftPublicHost = stableUrl.substring(stableUrl.indexOf(".") + 1)
+  }
+
   stage('Test') {
-    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}", "JAVA_OPTS=${javaOpts}","GRADLE_TEST_OPTS=${gradleTestOpts}","ENVIRONMENT=${springBootEnv}"]) {
+    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}", "JAVA_OPTS=${javaOpts}","GRADLE_TEST_OPTS=${gradleTestOpts}","ENVIRONMENT=${springBootEnv}","OPENSHIFT_PROJECT=${context.targetProject}","OPENSHIFT_PUBLIC_HOST=${openShiftPublicHost}"]) {
       def status = sh(script: "./gradlew clean test --stacktrace --no-daemon", returnStatus: true)
       junit(testResults:"build/test-results/installation*/*.xml, build/test-results/integration*/*.xml, build/test-results/acceptance*/*.xml", allowEmptyResults:true)
       stash(name: "installation-test-reports-junit-xml-${context.componentId}-${context.buildNumber}", includes: 'build/test-results/installation*/*.xml', allowEmpty: true)

--- a/e2e-spock-geb/files/src/test/resources/GebConfig.groovy
+++ b/e2e-spock-geb/files/src/test/resources/GebConfig.groovy
@@ -1,26 +1,23 @@
-import com.gargoylesoftware.htmlunit.BrowserVersion;
-import org.openqa.selenium.htmlunit.HtmlUnitDriver;
-import org.openqa.selenium.Proxy;
+import com.gargoylesoftware.htmlunit.BrowserVersion
+import org.openqa.selenium.htmlunit.HtmlUnitDriver
+import org.openqa.selenium.Proxy
 
 // Load application.properties
-def properties = new Properties()
-this.getClass().getResource( '/application.properties' ).withInputStream {
-    properties.load(it)
-}
+def properties = new SpecHelper().getApplicationProperties()
 
 // Selenium driver (True in constructor to use JavaScript)
-driver = { 
-    HtmlUnitDriver driver = new HtmlUnitDriver(BrowserVersion.CHROME, true) 
-    
+driver = {
+    HtmlUnitDriver driver = new HtmlUnitDriver(BrowserVersion.CHROME, true)
+
     def env = System.getenv()
     if(env.HTTP_PROXY) {
         Proxy proxy = new Proxy();
         URL url = new URL(env.HTTP_PROXY);
-        proxy.setHttpProxy("${url.getHost()}:${url.getPort()}"); 
+        proxy.setHttpProxy("${url.getHost()}:${url.getPort()}");
         proxy.setNoProxy(env.NO_PROXY)
         driver.setProxySettings(proxy);
     }
-    
+
     return driver
 }
 

--- a/e2e-spock-geb/files/src/test/resources/SpecHelper.groovy
+++ b/e2e-spock-geb/files/src/test/resources/SpecHelper.groovy
@@ -1,12 +1,28 @@
+import java.util.regex.Pattern
+
 class SpecHelper {
 
     public Properties getApplicationProperties() {
+        def env = System.getenv()
+
         def properties = new Properties()
         this.getClass().getResource('/application.properties').withInputStream {
-            properties.load(it)
+        	properties.load(it)
+        }
+
+        properties.each { key, value ->
+            def matcher = value =~ /\$\{(.*?)\}/
+            if (matcher.find()) {
+                matcher.each { match ->
+                    def nameToReplace = match[0]
+                    def valueToReplace = env[match[1]]
+
+                    value = value.replaceAll(Pattern.quote(nameToReplace), valueToReplace)
+                    properties[key] = value
+                }
+            }
         }
 
         return properties
     }
 }
-


### PR DESCRIPTION
This PR enhances the e2e-sock-geb quickstarter by:

- injecting `OPENSHIFT_PROJECT` and `OPENSHIFT_PUBLIC_HOST` environment into stage `test`
- parsing references to environment variables within `application.properties` in a Spring-like `${MY_ENV_VAR}` style