### PR TITLE
Add env var releaseStatusJiraIssueKey for e2e-spock-geb

### DIFF
--- a/release-manager/ocp-config/cd-pipeline.yml
+++ b/release-manager/ocp-config/cd-pipeline.yml
@@ -48,6 +48,8 @@ objects:
               value: WIP
             - name: sourceEnvironment
               value: dev
+            - name: releaseStatusJiraIssueKey
+              value: ''
           jenkinsfilePath: Jenkinsfile
         type: JenkinsPipeline
       triggers:


### PR DESCRIPTION
This PR adds an env variable `releaseStatusJiraIssueKey` to the Releases Manager's Jenkins pipeline strategy. This field will contain the key to a Jira issue Release Manager needs to update about pipeline success and failure. This is necessary so that our Jira workflows can transition to a successor state.

We chose to use this approach over a convention-based approach, e.g. have the Release Manager reference a Jira issue by a label or similar, to avoid ambiguity.