### PR TITLE
Move execution of pipeline stages into a single job in Release Manager

### DIFF
--- a/release-manager/files/Jenkinsfile
+++ b/release-manager/files/Jenkinsfile
@@ -1,45 +1,11 @@
 @Library('ods-mro-jenkins-shared-library@production')
-
 @Library('ods-jenkins-shared-library@production')
 
-def project = [:]
-def repos   = []
-
 /*
- * Use classic pipeline here because of blue ocean (1.18+) rendering bugs
- * with declarative pipelines.
+ * Use classic pipeline here because of blue ocean (1.18+)
+ * rendering bugs with declarative pipelines.
  */ 
 node {
-
-    checkout scm
-
-    def debugOn = true
-    withEnv (mroEnvironment(debugOn)) {
-
-        stage('Init') {
-            def result = phaseInit()
-            project = result.project
-            repos = result.repos
-        }
-
-        stage('Build') {
-            phaseBuild(project, repos)
-        }
-
-        stage('Deploy') {
-            phaseDeploy(project, repos)
-        }
-
-        stage('Test') {
-            phaseTest(project, repos)
-        }
-
-        stage('Release') {
-            phaseRelease(project, repos)
-        }
-
-        stage('Finalize') {
-            phaseFinalize(project, repos)
-        }
-    }
+    def config = [debug: true]
+    mroPipeline(config)
 }


### PR DESCRIPTION
Counter-part to https://github.com/opendevstack/ods-mro-jenkins-shared-library/pull/99.