### PR TITLE
Change default branch to env mapping

### DIFF
--- a/airflow-cluster/Jenkinsfile.template
+++ b/airflow-cluster/Jenkinsfile.template
@@ -13,7 +13,7 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
         remote       : sharedLibraryRepository,
         credentialsId: credentialsId])
 
-// See readme of shared library for usage and customization.
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
     image: "${dockerRegistry}/cd/jenkins-slave-airflow:@ods_image_tag@",
     projectId: projectId,
@@ -21,8 +21,8 @@ odsPipeline(
     openshiftBuildTimeout: 25,
     testResults : 'artifacts',
     branchToEnvironmentMapping: [
-            'master': 'test',
-            '*'     : 'dev'
+        'master': 'dev',
+        // 'release/*': 'test'
     ]
 ) { context ->
     stageDAGTest(context)

--- a/be-golang-plain/Jenkinsfile.template
+++ b/be-golang-plain/Jenkinsfile.template
@@ -14,20 +14,14 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])
 
-/*
-  See readme of shared library for usage and customization
-  @ https://github.com/opendevstack/ods-jenkins-shared-library/blob/master/README.md
-  eg. to create and set your own builder slave instead of
-  the base slave used here - the code of the base slave can be found at
-  https://github.com/opendevstack/ods-core/tree/master/jenkins/slave-base
- */
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-golang:@ods_image_tag@",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [
-    'master': 'test',
-    '*': 'dev'
+    'master': 'dev',
+    // 'release/*': 'test'
   ]
 ) { context ->
   stageCheckFormat(context)

--- a/be-java-springboot/Jenkinsfile.template
+++ b/be-java-springboot/Jenkinsfile.template
@@ -14,20 +14,14 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])
 
-/*
-  See readme of shared library for usage and customization
-  @ https://github.com/opendevstack/ods-jenkins-shared-library/blob/master/README.md
-  eg. to create and set your own builder slave instead of 
-  the maven/gradle slave used here - the code of the slave can be found at
-  https://github.com/opendevstack/ods-quickstarters/tree/master/common/jenkins-slaves/maven
- */ 
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-maven:@ods_image_tag@",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [
-    'master': 'test',
-    '*': 'dev'
+    'master': 'dev',
+    // 'release/*': 'test'
   ]
 ) { context ->
   stageBuild(context)

--- a/be-python-flask/Jenkinsfile.template
+++ b/be-python-flask/Jenkinsfile.template
@@ -14,20 +14,14 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])
 
-/*
-  See readme of shared library for usage and customization
-  @ https://github.com/opendevstack/ods-jenkins-shared-library/blob/master/README.md
-  eg. to create and set your own builder slave instead of
-  the python slave used here - the code of the python slave can be found at
-  https://github.com/opendevstack/ods-quickstarters/tree/master/common/jenkins-slaves/python
- */
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-python:@ods_image_tag@",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [
-    'master': 'test',
-    '*': 'dev'
+    'master': 'dev',
+    // 'release/*': 'test'
   ]
 ) { context ->
   stageTestSuite(context, context.nexusHostWithBasicAuth, context.nexusHost.tokenize('//')[1])

--- a/be-scala-akka/Jenkinsfile.template
+++ b/be-scala-akka/Jenkinsfile.template
@@ -14,20 +14,14 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])
 
-/*
-  See readme of shared library for usage and customization
-  @ https://github.com/opendevstack/ods-jenkins-shared-library/blob/master/README.md
-  eg. to create and set your own builder slave instead of 
-  the scala/sbt slave used here - the code of the sbt slave can be found at
-  https://github.com/opendevstack/ods-quickstarters/tree/master/common/jenkins-slaves/scala
- */ 
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-scala:@ods_image_tag@",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [
-    'master': 'test',
-    '*': 'dev'
+    'master': 'dev',
+    // 'release/*': 'test'
   ]
 ) { context ->
   stageBuild(context)

--- a/be-typescript-express/Jenkinsfile.template
+++ b/be-typescript-express/Jenkinsfile.template
@@ -14,20 +14,14 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])
 
-/*
-  See readme of shared library for usage and customization
-  @ https://github.com/opendevstack/ods-jenkins-shared-library/blob/master/README.md
-  eg. to create and set your own builder slave instead of
-  the node js slave used here - the code of the slave can be found at
-  https://github.com/opendevstack/ods-quickstarters/tree/master/common/jenkins-slaves/nodejs10-angular
- */
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-nodejs10-angular:@ods_image_tag@",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [
-    'master': 'test',
-    '*': 'dev'
+    'master': 'dev',
+    // 'release/*': 'test'
   ]
 ) { context ->
   stageBuild(context)

--- a/docker-plain/Jenkinsfile.template
+++ b/docker-plain/Jenkinsfile.template
@@ -14,20 +14,14 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])
 
-/*
-  See readme of shared library for usage and customization
-  @ https://github.com/opendevstack/ods-jenkins-shared-library/blob/master/README.md
-  eg. to create and set your own builder slave instead of 
-  the base slave used here - the code of the base slave can be found at
-  https://github.com/opendevstack/ods-core/tree/master/jenkins/slave-base
- */ 
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-base:@ods_image_tag@",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [
-    'master': 'test',
-    '*': 'dev'
+    'master': 'dev',
+    // 'release/*': 'test'
   ]
 ) { context ->
   stageBuild(context)

--- a/ds-jupyter-notebook/Jenkinsfile.template
+++ b/ds-jupyter-notebook/Jenkinsfile.template
@@ -14,20 +14,14 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])
 
-/*
-  See readme of shared library for usage and customization
-  @ https://github.com/opendevstack/ods-jenkins-shared-library/blob/master/README.md
-  eg. to create and set your own builder slave instead of
-  the base slave used here - the code of the base slave can be found at
-  https://github.com/opendevstack/ods-core/tree/master/jenkins/slave-base
- */
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-base:@ods_image_tag@",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [
-    'master': 'test',
-    '*': 'dev'
+    'master': 'dev',
+    // 'release/*': 'test'
   ]
 ) { context ->
   stageStartOpenshiftBuild(context, [nexusHostWithBasicAuth: context.nexusHostWithBasicAuth, nexusHostWithoutScheme: context.nexusHost.tokenize('//')[1]])

--- a/ds-ml-service/Jenkinsfile.template
+++ b/ds-ml-service/Jenkinsfile.template
@@ -21,7 +21,7 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
         remote       : sharedLibraryRepository,
         credentialsId: credentialsId])
 
-// See readme of shared library for usage and customization.
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
     image: "${dockerRegistry}/cd/jenkins-slave-python:@ods_image_tag@",
     projectId: projectId,
@@ -29,8 +29,8 @@ odsPipeline(
     testResults : 'tests-results',
     openshiftBuildTimeout: 25,
     branchToEnvironmentMapping: [
-        'master': 'test',
-        '*'     : 'dev'
+        'master': 'dev',
+        // 'release/*': 'test'
     ]
 ) { context ->
     stageScanForSonarqube(context)

--- a/ds-rshiny/Jenkinsfile.template
+++ b/ds-rshiny/Jenkinsfile.template
@@ -14,20 +14,14 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])
 
-/*
-  See readme of shared library for usage and customization
-  @ https://github.com/opendevstack/ods-jenkins-shared-library/blob/master/README.md
-  eg. to create and set your own builder slave instead of
-  the base slave used here - the code of the base slave can be found at
-  https://github.com/opendevstack/ods-core/tree/master/jenkins/slave-base
- */
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-base:@ods_image_tag@",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [
-    'master': 'test',
-    '*': 'dev'
+    'master': 'dev',
+    // 'release/*': 'test'
   ]
 ) { context ->
   stageStartOpenshiftBuild(context)

--- a/e2e-cypress/Jenkinsfile.template
+++ b/e2e-cypress/Jenkinsfile.template
@@ -14,20 +14,14 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])
 
-/*
-  See readme of shared library for usage and customization
-  @ https://github.com/opendevstack/ods-jenkins-shared-library/blob/master/README.md
-  eg. to create and set your own builder slave instead of 
-  the node js slave used here - the code of the slave can be found at
-  https://github.com/opendevstack/ods-quickstarters/tree/master/common/jenkins-slaves/nodejs10-angular
- */ 
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-nodejs10-angular:@ods_image_tag@",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [
-    'master': 'test',
-    '*': 'dev'
+    'master': 'dev',
+    // 'release/*': 'test'
   ]
 ) { context ->
   stageTest(context)

--- a/fe-angular/Jenkinsfile.template
+++ b/fe-angular/Jenkinsfile.template
@@ -14,20 +14,14 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])
 
-/*
-  See readme of shared library for usage and customization
-  @ https://github.com/opendevstack/ods-jenkins-shared-library/blob/master/README.md
-  eg. to create and set your own builder slave instead of 
-  the base slave used here - the code of the base slave can be found at
-  https://github.com/opendevstack/ods-core/tree/master/jenkins/slave-base
- */ 
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-nodejs10-angular:@ods_image_tag@",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [
-    'master': 'test',
-    '*': 'dev'
+    'master': 'dev',
+    // 'release/*': 'test'
   ]
 ) { context ->
   stageBuild(context)

--- a/fe-ionic/Jenkinsfile.template
+++ b/fe-ionic/Jenkinsfile.template
@@ -14,20 +14,14 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])
 
-/*
-  See readme of shared library for usage and customization
-  @ https://github.com/opendevstack/ods-jenkins-shared-library/blob/master/README.md
-  eg. to create and set your own builder slave instead of
-  the node js slave used here - the code of the slave can be found at
-  https://github.com/opendevstack/ods-quickstarters/tree/master/common/jenkins-slaves/nodejs10-angular
- */
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-nodejs10-angular:@ods_image_tag@",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [
-    'master': 'test',
-    '*': 'dev'
+    'master': 'dev',
+    // 'release/*': 'test'
   ]
 ) { context ->
   stageBuild(context)

--- a/fe-react/Jenkinsfile.template
+++ b/fe-react/Jenkinsfile.template
@@ -14,20 +14,14 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])
 
-/*
-  See readme of shared library for usage and customization
-  @ https://github.com/opendevstack/ods-jenkins-shared-library/blob/master/README.md
-  eg. to create and set your own builder slave instead of 
-  the node js slave used here - the code of the slave can be found at
-  https://github.com/opendevstack/ods-quickstarters/tree/master/common/jenkins-slaves/nodejs10-angular
- */
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-nodejs10-angular:@ods_image_tag@",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [
-    'master': 'test',
-    '*': 'dev'
+    'master': 'dev',
+    // 'release/*': 'test'
   ]
 ) { context ->
   stageBuild(context)

--- a/fe-vue/Jenkinsfile.template
+++ b/fe-vue/Jenkinsfile.template
@@ -13,14 +13,14 @@ library identifier: 'ods-library@@ods_git_ref@', retriever: modernSCM(
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])
 
-// See readme of shared library for usage and customization.
+// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-nodejs10-angular:@ods_image_tag@",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [
-    'master': 'test',
-    '*': 'dev'
+    'master': 'dev',
+    // 'release/*': 'test'
   ]
 ) { context ->
   stageBuild(context)


### PR DESCRIPTION
Going forward, master will be build in dev.

This is due to upcoming changes to the MRO, which will also default to
master being build in dev, and assumes that only the MRO promotes
artifacts to test.