### PR TITLE
Configure JaCoCo to generate XML reports

### DIFF
--- a/be-java-springboot/sonar-project.properties.template
+++ b/be-java-springboot/sonar-project.properties.template
@@ -17,4 +17,4 @@ sonar.sourceEncoding=UTF-8
 sonar.java.binaries=build/classes
 sonar.java.libraries=docker
 sonar.junit.reportPaths=build/test-results/test
-sonar.jacoco.reportPaths=build/jacoco/test.exec
+sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml

--- a/be-java-springboot/templates/build-4.10.gradle
+++ b/be-java-springboot/templates/build-4.10.gradle
@@ -89,6 +89,7 @@ dependencies {
 test {
     outputs.dir snippetsDir
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
 
 asciidoctor {
@@ -107,6 +108,11 @@ bootJar {
     }
 }
 
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+}
 
 publishing {
     repositories {


### PR DESCRIPTION
Fixes #225.

@clemensutschig I would actually propose to apply this fix for 2.x as well, since code coverage is broken there since the update of the Java plugin to 6.2. Do you agree? 