### PR TITLE
Remove projectid / componentId variables and set directly on boilerplate

### DIFF
--- a/airflow-cluster/Jenkinsfile.template
+++ b/airflow-cluster/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = 'airflow-worker'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
     imageStreamTag: 'cd/jenkins-slave-airflow:@ods_image_tag@',
-    projectId: projectId,
-    componentId: componentId,
+    projectId: '@project_id@',
+    componentId: 'airflow-worker',
     testResults : 'artifacts',
     branchToEnvironmentMapping: [
         'master': 'dev',

--- a/be-fe-mono-repo-plain/Jenkinsfile.template
+++ b/be-fe-mono-repo-plain/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-base:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/*': 'test'

--- a/be-golang-plain/Jenkinsfile.template
+++ b/be-golang-plain/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-golang:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/*': 'test'

--- a/be-java-springboot/Jenkinsfile.template
+++ b/be-java-springboot/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-maven:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/*': 'test'

--- a/be-python-flask/Jenkinsfile.template
+++ b/be-python-flask/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-python:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/*': 'test'

--- a/be-scala-akka/Jenkinsfile.template
+++ b/be-scala-akka/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-scala:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   testResults: "target/test-reports",
   branchToEnvironmentMapping: [
     'master': 'dev',

--- a/be-scala-play/Jenkinsfile.template
+++ b/be-scala-play/Jenkinsfile.template
@@ -1,14 +1,12 @@
 /* generated jenkins file used for building and deploying @component_id@ in projects @project_id@ */
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-scala:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   testResults: 'target/test-reports',
   branchToEnvironmentMapping: [
     'master': 'test',

--- a/be-typescript-express/Jenkinsfile.template
+++ b/be-typescript-express/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-nodejs10-angular:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/*': 'test'

--- a/docker-plain/Jenkinsfile.template
+++ b/docker-plain/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-base:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/*': 'test'

--- a/ds-jupyter-notebook/Jenkinsfile.template
+++ b/ds-jupyter-notebook/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-base:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/*': 'test'

--- a/ds-ml-service/Jenkinsfile.template
+++ b/ds-ml-service/Jenkinsfile.template
@@ -5,11 +5,10 @@ def predictionServiceName = "${componentId}-prediction-service"
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-python:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   testResults : 'tests-results',
   openshiftBuildTimeout: 25,
   openshiftRolloutTimeout: 10,

--- a/ds-rshiny/Jenkinsfile.template
+++ b/ds-rshiny/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-base:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   openshiftBuildTimeout: 30,  
   branchToEnvironmentMapping: [
     'master': 'dev',

--- a/e2e-cypress/Jenkinsfile.template
+++ b/e2e-cypress/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-nodejs10-angular:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/*': 'test'

--- a/e2e-spock-geb/Jenkinsfile.template
+++ b/e2e-spock-geb/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-maven:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/*': 'test'

--- a/fe-angular/Jenkinsfile.template
+++ b/fe-angular/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-nodejs10-angular:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/*': 'test'

--- a/fe-ionic/Jenkinsfile.template
+++ b/fe-ionic/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-nodejs10-angular:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/*': 'test'

--- a/fe-react/Jenkinsfile.template
+++ b/fe-react/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-nodejs10-angular:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/*': 'test'

--- a/fe-vue/Jenkinsfile.template
+++ b/fe-vue/Jenkinsfile.template
@@ -1,13 +1,11 @@
-def final projectId = '@project_id@'
-def final componentId = '@component_id@'
+// See https://www.opendevstack.org/ods-documentation/ for usage and customization.
 
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
-// See https://www.opendevstack.org/ods-documentation/ods-jenkins-shared-library/latest/index.html for usage and customization.
 odsComponentPipeline(
   imageStreamTag: 'cd/jenkins-slave-nodejs10-angular:@ods_image_tag@',
-  projectId: projectId,
-  componentId: componentId,
+  projectId: '@project_id@',
+  componentId: '@component_id@',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/*': 'test'


### PR DESCRIPTION
Project ID and component ID are accessible via context.

Closes #244.

Fixes #246. There isn't a nicer, more specific way that is still easy to maintain
to link to the currently released version of ODS documentation. On the
on hand that is unfortunate because people need to click on "Jenkins
Shared library", on the other hand it might help that people get
familiar with the documentation which is not bad either.

FYI @SimonGolms