### PR TITLE
Update Go to 1.14

### DIFF
--- a/common/jenkins-slaves/golang/Dockerfile.rhel7
+++ b/common/jenkins-slaves/golang/Dockerfile.rhel7
@@ -2,7 +2,7 @@ FROM cd/jenkins-slave-base
 
 LABEL maintainer="Michael Sauter <michael.sauter@boehringer-ingelheim.com>"
 
-ENV GO_VERSION 1.12.6
+ENV GO_VERSION 1.14.2
 
 RUN cd /tmp && \
     curl -LO https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && \
@@ -14,7 +14,7 @@ RUN cd /tmp && \
 ENV PATH $PATH:/usr/local/go/bin
 ENV GOBIN /usr/local/bin
 
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.17.1
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.25.0
 
 RUN go get -u github.com/jstemmer/go-junit-report
 


### PR DESCRIPTION
Depends on https://github.com/opendevstack/ods-core/pull/497.

Closes #248.