### PR TITLE
changes required to make yarn use the internal registry by default

### DIFF
--- a/common/jenkins-slaves/nodejs10-angular/Dockerfile.rhel7
+++ b/common/jenkins-slaves/nodejs10-angular/Dockerfile.rhel7
@@ -61,17 +61,13 @@ RUN curl --silent --location https://rpm.nodesource.com/setup_10.x | bash - && \
     yum install -y yarn && \
     yum clean all -y
 
-COPY npmrc $HOME/.npm-global/etc/npmrc
-COPY npmrc $HOME/.npmrc
-COPY yarnrc $HOME/.yarnrc
-
-RUN sed -i "s|NEXUS_HOST|$NEXUS_HOST|g" $HOME/.npm-global/etc/npmrc && \
-    sed -i "s|NEXUS_AUTH|$(echo -n $NEXUS_AUTH | base64)|g" $HOME/.npm-global/etc/npmrc && \
-    sed -i "s|NEXUS_HOST|$NEXUS_HOST|g" $HOME/.npmrc && \
-    sed -i "s|NEXUS_AUTH|$(echo -n $NEXUS_AUTH | base64)|g" $HOME/.npmrc && \
-    sed -i "s|NEXUS_HOST|$NEXUS_HOST|g" $HOME/.yarnrc && \
+RUN npm config set registry=$NEXUS_HOST/repository/npmjs/ && \
+    npm config set always-auth=true && \
+    npm config set _auth=$(echo -n $NEXUS_AUTH | base64) && \
+    npm config set email=no-reply@opendevstack.org && \
     npm config set ca=null && \
     npm config set strict-ssl=false && \
+    yarn config set registry $NEXUS_HOST/repository/npmjs/ -g && \
     npm install -g @angular/cli@8.0.1 --unsafe-perm=true --allow-root && \
     npm install -g cypress@3.3.1 --unsafe-perm=true --allow-root > /dev/null && \
     npm --version && \

--- a/common/jenkins-slaves/nodejs10-angular/Dockerfile.rhel7
+++ b/common/jenkins-slaves/nodejs10-angular/Dockerfile.rhel7
@@ -62,9 +62,14 @@ RUN curl --silent --location https://rpm.nodesource.com/setup_10.x | bash - && \
     yum clean all -y
 
 COPY npmrc $HOME/.npm-global/etc/npmrc
+COPY npmrc $HOME/.npmrc
+COPY yarnrc $HOME/.yarnrc
 
 RUN sed -i "s|NEXUS_HOST|$NEXUS_HOST|g" $HOME/.npm-global/etc/npmrc && \
     sed -i "s|NEXUS_AUTH|$(echo -n $NEXUS_AUTH | base64)|g" $HOME/.npm-global/etc/npmrc && \
+    sed -i "s|NEXUS_HOST|$NEXUS_HOST|g" $HOME/.npmrc && \
+    sed -i "s|NEXUS_AUTH|$(echo -n $NEXUS_AUTH | base64)|g" $HOME/.npmrc && \
+    sed -i "s|NEXUS_HOST|$NEXUS_HOST|g" $HOME/.yarnrc && \
     npm config set ca=null && \
     npm config set strict-ssl=false && \
     npm install -g @angular/cli@8.0.1 --unsafe-perm=true --allow-root && \

--- a/common/jenkins-slaves/nodejs10-angular/npmrc
+++ b/common/jenkins-slaves/nodejs10-angular/npmrc
@@ -1,4 +1,0 @@
-registry=NEXUS_HOST/repository/npmjs/
-always-auth=true
-_auth=NEXUS_AUTH
-email=no-reply@opendevstack.org

--- a/common/jenkins-slaves/nodejs10-angular/yarnrc
+++ b/common/jenkins-slaves/nodejs10-angular/yarnrc
@@ -1,0 +1,1 @@
+registry "NEXUS_HOST/repository/npmjs//"

--- a/common/jenkins-slaves/nodejs10-angular/yarnrc
+++ b/common/jenkins-slaves/nodejs10-angular/yarnrc
@@ -1,1 +1,0 @@
-registry "NEXUS_HOST/repository/npmjs//"


### PR DESCRIPTION
fix for #275 - according to my testing this makes sure the slave is defaulted to the internal registry for npm and yarn