### PR TITLE
fix path to coverage analysis data

### DIFF
--- a/fe-angular/sonar-project.properties.template
+++ b/fe-angular/sonar-project.properties.template
@@ -20,4 +20,4 @@ sonar.coverage.exclusions=**/*.spec.ts
 sonar.exclusions=**/*.html,**/*.scss,**/*.json,**/*.ico,**/*.svg
 
 # Define coverage information inside the Angular project
-sonar.typescript.lcov.reportPaths=coverage/lcov.info
+sonar.javascript.lcov.reportPaths=coverage/@component_id@/lcov.info


### PR DESCRIPTION
The path to the lcov file also needs the component id. The path is usually defined within the ``karma.conf.js`` under ``coverageIstanbulReporter``. ``karma.conf.js`` gets generated during quickstarter provisioning by the ``ng new`` command.

this fix also relates to #213