### PR TITLE
Add missing label

### DIFF
--- a/common/jenkins-slaves/nodejs12/ocp-config/template.yaml
+++ b/common/jenkins-slaves/nodejs12/ocp-config/template.yaml
@@ -23,6 +23,8 @@ objects:
   kind: ImageStream
   metadata:
     name: jenkins-slave-nodejs12
+    labels:
+      app: jenkins-slave-nodejs12
   spec:
     dockerImageRepository: jenkins-slave-nodejs12
     lookupPolicy:
@@ -31,6 +33,8 @@ objects:
   kind: BuildConfig
   metadata:
     name: jenkins-slave-nodejs12
+    labels:
+      app: jenkins-slave-nodejs12
   spec:
     failedBuildsHistoryLimit: 5
     output:


### PR DESCRIPTION
That explains why Tailor did not "see" the resources in the template. That said, for now you don't need this Jenkins slave at all. Once it is required by some quickstarter, it will be added into the `Makefile`.