### PR TITLE
Fix/url host mess

### DIFF
--- a/airflow-cluster/Jenkinsfile.template
+++ b/airflow-cluster/Jenkinsfile.template
@@ -28,7 +28,7 @@ def stageDAGTest(def context) {
 
 def stageUnitTest(def context) {
     stage('Unit Tests') {
-        sh "pip install -i ${context.nexusHostWithBasicAuth}/repository/pypi-all/simple --trusted-host ${context.nexusHost.tokenize('//')[1]} -r src/requirements.txt --user"
+        sh "pip install -i ${context.nexusHostWithBasicAuth}/repository/pypi-all/simple --trusted-host ${context.nexusHostWithoutScheme} -r src/requirements.txt --user"
         sh 'sh test_all.sh'
     }
 }

--- a/be-java-springboot/Jenkinsfile.template
+++ b/be-java-springboot/Jenkinsfile.template
@@ -23,7 +23,7 @@ def stageBuild(def context) {
     springBootEnv = 'dev'
   }
   stage('Build and Unit Test') {
-    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_URL=${context.nexusUrl}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}", "JAVA_OPTS=${javaOpts}","GRADLE_TEST_OPTS=${gradleTestOpts}","ENVIRONMENT=${springBootEnv}"]) {
+    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}", "JAVA_OPTS=${javaOpts}","GRADLE_TEST_OPTS=${gradleTestOpts}","ENVIRONMENT=${springBootEnv}"]) {
       def status = sh(script: "./gradlew clean build --stacktrace --no-daemon", returnStatus: true)
       if (status != 0) {
         error "Build failed!"

--- a/be-java-springboot/postProcessProjectsettings.sh
+++ b/be-java-springboot/postProcessProjectsettings.sh
@@ -16,7 +16,7 @@ USE_LEGACY_NEXUS_UPLOAD_SCRIPT=0
 
 if [[ $version == "4.9" ]]; then
 	sed -i.bak '/springBootVersion =/a \
-	    nexus_url = "\${project.findProperty("nexus_url") ?: System.getenv("NEXUS_URL") ?: System.getenv("NEXUS_HOST")}"\
+	    nexus_url = "\${project.findProperty("nexus_url") ?: System.getenv("NEXUS_HOST")}"\
 	    nexus_folder = "candidates"\
 	    nexus_user = "\${project.findProperty("nexus_user") ?: System.getenv("NEXUS_USERNAME")}"\
 	    nexus_pw = "\${project.findProperty("nexus_pw") ?: System.getenv("NEXUS_PASSWORD")}"\

--- a/be-java-springboot/templates/build-4.10.gradle
+++ b/be-java-springboot/templates/build-4.10.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext
             {
-                nexus_url = "${project.findProperty('nexus_url') ?: System.getenv("NEXUS_URL") ?: System.getenv('NEXUS_HOST')}"
+                nexus_url = "${project.findProperty('nexus_url') ?: System.getenv('NEXUS_HOST')}"
                 nexus_user = "${project.findProperty('nexus_user') ?: System.getenv('NEXUS_USERNAME')}"
                 nexus_pw = "${project.findProperty('nexus_pw') ?: System.getenv('NEXUS_PASSWORD')}"
                 no_nexus = (project.findProperty('no_nexus') ?: System.getenv('NO_NEXUS') ?: false).toBoolean()

--- a/be-python-flask/Jenkinsfile.template
+++ b/be-python-flask/Jenkinsfile.template
@@ -9,19 +9,19 @@ odsComponentPipeline(
     // 'release/': 'test'
   ]
 ) { context ->
-  stageTestSuite(context, context.nexusHostWithBasicAuth, context.nexusHost.tokenize('//')[1])
+  stageTestSuite(context)
   odsComponentStageScanWithSonar(context)
   stageBuild(context)
   odsComponentStageBuildOpenShiftImage(context, [
     buildArgs: [
       nexusHostWithBasicAuth: context.nexusHostWithBasicAuth,
-      nexusHostWithoutScheme: context.nexusHost.tokenize('//')[1]
+      nexusHostWithoutScheme: context.nexusHostWithoutScheme
     ]
   ])
   odsComponentStageRolloutOpenShiftDeployment(context)
 }
 
-def stageTestSuite(def context, def nexusHostWithBasicAuth, def nexusHostWithoutScheme) {
+def stageTestSuite(def context) {
   String testLocation = 'build/test-results/test'
   String coverageLocation = 'build/test-results/coverage'
 
@@ -29,7 +29,7 @@ def stageTestSuite(def context, def nexusHostWithBasicAuth, def nexusHostWithout
     sh """
       virtualenv testsuite
       . ./testsuite/bin/activate
-      pip install -i ${nexusHostWithBasicAuth}/repository/pypi-all/simple --trusted-host ${nexusHostWithoutScheme} -r tests/requirements.txt
+      pip install -i ${context.nexusHostWithBasicAuth}/repository/pypi-all/simple --trusted-host ${context.nexusHostWithoutScheme} -r tests/requirements.txt
       pip check
       mkdir -p ${testLocation}
       mkdir -p ${coverageLocation}

--- a/ds-jupyter-notebook/Jenkinsfile.template
+++ b/ds-jupyter-notebook/Jenkinsfile.template
@@ -13,7 +13,7 @@ odsComponentPipeline(
   odsComponentStageBuildOpenShiftImage(context, [
     buildArgs: [
       nexusHostWithBasicAuth: context.nexusHostWithBasicAuth,
-      nexusHostWithoutScheme: context.nexusHost.tokenize('//')[1]
+      nexusHostWithoutScheme: context.nexusHostWithoutScheme
     ]
   ])
 

--- a/ds-ml-service/Jenkinsfile.template
+++ b/ds-ml-service/Jenkinsfile.template
@@ -16,7 +16,7 @@ odsComponentPipeline(
   def predictionServiceName = "${context.componentId}-prediction-service"
   def buildArgs = [
     "nexusHostWithBasicAuth" : context.nexusHostWithBasicAuth,
-    "nexusHostWithoutScheme" : context.nexusHost.tokenize('//')[1],
+    "nexusHostWithoutScheme" : context.nexusHostWithoutScheme,
     "serviceType" : ""
   ]
 
@@ -66,7 +66,7 @@ def stageTrainingUnitTests(def context, def trainingPod) {
 
 def stageTraining(def context, def trainingPod) {
   stage('Train Model') {
-    sh(returnStdout: true, script:"pip install -i ${context.nexusHostWithBasicAuth}/repository/pypi-all/simple --trusted-host ${context.nexusHost.tokenize('//')[1]}  requests --user")
+    sh(returnStdout: true, script:"pip install -i ${context.nexusHostWithBasicAuth}/repository/pypi-all/simple --trusted-host ${context.nexusHostWithoutScheme}  requests --user")
 
     def trainingRoute = "http://localhost:8080"
     def trainingPassword = sh(returnStdout: true, script:"oc get secret ${context.componentId}-training-secret -o yaml -n ${context.targetProject} | grep password: | cut -d':' -f2 ").trim()

--- a/e2e-cypress/Jenkinsfile.template
+++ b/e2e-cypress/Jenkinsfile.template
@@ -15,7 +15,7 @@ odsComponentPipeline(
 def stageTest(def context) {
 
   stage('Integration Test') {
-    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_URL=${context.nexusUrl}","OPENSHIFT_PROJECT=${context.targetProject}","OPENSHIFT_APP_DOMAIN=${context.getOpenshiftApplicationDomain()}"]) {
+    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}","OPENSHIFT_PROJECT=${context.targetProject}","OPENSHIFT_APP_DOMAIN=${context.getOpenshiftApplicationDomain()}"]) {
       sh "npm install"
       def status = sh(script: "npm run e2e", returnStatus: true)
       junit(testResults:"build/test-results/*.xml", allowEmptyResults:true)

--- a/e2e-spock-geb/Jenkinsfile.template
+++ b/e2e-spock-geb/Jenkinsfile.template
@@ -23,7 +23,7 @@ def stageTest(def context) {
 
   stage('Integration Test') {
   	sh (script: "chmod a+x gradle*", label : "allow gradle to execute")
-    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_URL=${context.nexusUrl}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}", "JAVA_OPTS=${javaOpts}","GRADLE_TEST_OPTS=${gradleTestOpts}","ENVIRONMENT=${springBootEnv}","OPENSHIFT_PROJECT=${context.targetProject}","OPENSHIFT_APP_DOMAIN=${context.getOpenshiftApplicationDomain()}"]) {
+    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}", "JAVA_OPTS=${javaOpts}","GRADLE_TEST_OPTS=${gradleTestOpts}","ENVIRONMENT=${springBootEnv}","OPENSHIFT_PROJECT=${context.targetProject}","OPENSHIFT_APP_DOMAIN=${context.getOpenshiftApplicationDomain()}"]) {
       def status = sh(script: "./gradlew clean test --stacktrace --no-daemon", returnStatus: true)
       junit(testResults:"build/test-results/installation*/*.xml, build/test-results/integration*/*.xml, build/test-results/acceptance*/*.xml", allowEmptyResults:true)
       stash(name: "installation-test-reports-junit-xml-${context.componentId}-${context.buildNumber}", includes: 'build/test-results/installation*/*.xml', allowEmpty: true)

--- a/fe-angular/Jenkinsfile.template
+++ b/fe-angular/Jenkinsfile.template
@@ -18,7 +18,7 @@ odsComponentPipeline(
 
 def stageBuild(def context) {
   stage('Build') {
-    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_URL=${context.nexusUrl}"]) {
+    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}"]) {
       sh "npm install"
       sh "npm run build"
     }

--- a/fe-ionic/Jenkinsfile.template
+++ b/fe-ionic/Jenkinsfile.template
@@ -19,7 +19,7 @@ odsComponentPipeline(
 
 def stageBuild(def context) {
   stage('Build') {
-    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_URL=${context.nexusUrl}"]) {
+    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}"]) {
       sh "yarn global add ionic@3.19.0"
       sh "yarn install"
       if ('master'.equals(context.gitBranch)) {

--- a/fe-react/Jenkinsfile.template
+++ b/fe-react/Jenkinsfile.template
@@ -18,7 +18,7 @@ odsComponentPipeline(
 
 def stageBuild(def context) {
   stage('Build') {
-    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_URL=${context.nexusUrl}"]) {
+    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}"]) {
       sh "npm ci"
       sh "npm run build"
     }

--- a/fe-vue/Jenkinsfile.template
+++ b/fe-vue/Jenkinsfile.template
@@ -19,7 +19,7 @@ odsComponentPipeline(
 
 def stageBuild(def context) {
   stage('Build') {
-    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_URL=${context.nexusUrl}"]) {
+    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}"]) {
       sh "npm install"
       sh "npm run build"
     }


### PR DESCRIPTION
Reverts a few changes done in #314.

NEXUS_HOST was used in 2.x, and to avoid any confusion we stick with this.
Otherwise components provisioned with 3.x would use NEXUS_URL and older
components would use NEXUS_HOST, even within the same project. That
would be odd.

Also makes use of new property `nexusHostWithoutScheme`.

Depends on https://github.com/opendevstack/ods-jenkins-shared-library/pull/371.