### PR TITLE
update be-scala-play quickstarter and jenkins-scala-slave

### DIFF
--- a/be-scala-play/be-scala-play.g8/src/main/g8/build.sbt
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/build.sbt
@@ -7,9 +7,9 @@ lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(PlayKeys.playDefaultPort := 8080)
 
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.2"
 
-credentials += Credentials(Path.userHome / ".sbt" / "credentials")
+credentials += Credentials(Path.userHome / ".sbt" / ".credentials")
 
 val compileDependencies = Seq(
   guice,
@@ -17,7 +17,7 @@ val compileDependencies = Seq(
 )
 
 val testDependencies = Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test
+  "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
 )
 
 libraryDependencies ++= compileDependencies ++ testDependencies

--- a/be-scala-play/be-scala-play.g8/src/main/g8/project/build.properties
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.7
+sbt.version=1.3.12

--- a/be-scala-play/be-scala-play.g8/src/main/g8/project/plugins.sbt
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/project/plugins.sbt
@@ -1,5 +1,5 @@
-credentials += Credentials(Path.userHome / ".sbt" / "credentials")
+credentials += Credentials(Path.userHome / ".sbt" / ".credentials")
 
-addSbtPlugin("com.typesafe.play"        % "sbt-plugin"          % "2.8.0")
-addSbtPlugin("org.scalameta"            % "sbt-scalafmt"        % "2.3.0")
+addSbtPlugin("com.typesafe.play"        % "sbt-plugin"          % "2.8.2")
+addSbtPlugin("org.scalameta"            % "sbt-scalafmt"        % "2.4.0")
 addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8-scaffold" % "0.11.0")

--- a/common/jenkins-slaves/scala/docker/Dockerfile
+++ b/common/jenkins-slaves/scala/docker/Dockerfile
@@ -1,79 +1,47 @@
-FROM opendevstackorg/ods-jenkins-slave-base-centos7:latest
+FROM opendevstackorg/ods-jenkins-slave-base-centos7
 
-LABEL maintainer="Clemens Utschig <clemens.utschig-utschig@boehringer-ingelheim.com>"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="jenkins-slave-nodejs-rhel7-docker" \
-      name="openshift3/jenkins-slave-nodejs-rhel7" \
-      version="3.6" \
-      architecture="x86_64" \
-      release="4" \
-      io.k8s.display-name="Jenkins Slave Scala" \
-      io.k8s.description="The jenkins slave scala image has the scala tools on top of the jenkins slave base image." \
-      io.openshift.tags="openshift,jenkins,slave,scala"
+LABEL maintainer="Jan Frank <jan.frank@boehringer-ingelheim.com>"
 
 ARG nexusUrl
 ARG nexusUsername
 ARG nexusPassword
 
-ENV HOME=/home/jenkins \
-    BASH_ENV=/usr/local/bin/scl_enable \
-    ENV=/usr/local/bin/scl_enable \
-    PROMPT_COMMAND=". /usr/local/bin/scl_enable" \
-    SBT_CREDENTIALS="$HOME/.sbt/credentials"
-    
-COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
-    
-RUN set -x \
-    && INSTALL_PKGS="gcc make openssl-devel zlib-devel" \
-    && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
-    && yum clean all \
-    && rm -rf /var/cache/yum/*
+ENV SBT_VERSION=1.3.12
+ENV SBT_CREDENTIALS="$HOME/.sbt/.credentials"
 
-RUN yum -y install java-1.8.0-openjdk \
+RUN yum -y install java-1.8.0-openjdk-devel \
     && alternatives --set java $(alternatives --display java | awk '/family.*x86_64/ { print $1; }')
 
-ENV SBT_VERSION=1.1.6
-
 RUN curl -O -L http://dl.bintray.com/sbt/rpm/sbt-$SBT_VERSION.rpm && \
-     yum -y install sbt-$SBT_VERSION.rpm
-	
-RUN	mkdir -p $HOME/.sbt/1.0/plugins && \
-	mkdir -p $HOME/.sbt/0.13/plugins && \
-    mkdir -p /tmp/scala	
-	
-# copy nexus config over
-COPY sbtconfig/credentials $HOME/.sbt/
-COPY sbtconfig/repositories $HOME/.sbt/
-COPY sbtconfig/credentials.sbt $HOME/.sbt/1.0/plugins/
-COPY sbtconfig/credentials.sbt $HOME/.sbt/0.13/plugins/
-	
-# really weird sbt rpm happyness :()
-COPY sbtopts /usr/share/sbt-launcher-packaging/conf/sbtopts 
-COPY sbtopts /usr/share/sbt/conf/sbtopts 
- 	 
-# temp test hw scala / -ivy $HOME/.ivy2 -Dsbt.global.base=$HOME/.sbt
-COPY test/* /tmp/scala/
+    yum -y install sbt-$SBT_VERSION.rpm && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+COPY sbtconfig/repositories $HOME/.sbt/repositories
+COPY sbtconfig/credentials.sbt $HOME/.sbt/1.0/plugins/credentials.sbt
+COPY sbtconfig/credentials $HOME/.sbt/.credentials
+COPY sbtconfig/sbtopts /etc/sbt/sbtopts
+COPY set_sbt_proxy.sh /tmp/set_sbt_proxy.sh
 
 RUN cat $HOME/.sbt/repositories | sed -e "s|NEXUS_URL|$nexusUrl|g" > $HOME/.sbt/repositories.tmp && \
     mv $HOME/.sbt/repositories.tmp $HOME/.sbt/repositories  && \
     nexusHost=$(echo $nexusUrl | sed -e "s|https://||g" | sed -e "s|http://||g") && \
     nexusHost=$(echo $nexusHost | sed -e "s|:.*||g") && \
-    sed -i.bak -e "s|NEXUS_HOST|$nexusHost|g" $HOME/.sbt/credentials && \
-    sed -i.bak -e "s|NEXUS_USERNAME|$nexusUsername|g" $HOME/.sbt/credentials && \
-    sed -i.bak -e "s|NEXUS_PASSWORD|$nexusPassword|g" $HOME/.sbt/credentials && \
-    rm $HOME/.sbt/credentials.bak && \
-    cd /tmp/scala && \
-    . /tmp/set_java_proxy.sh && \
-    export SBT_OPTS=$JAVA_OPTS" -Duser.home=/home/jenkins" && \
-    sbt -v run && echo "c" && \
-    rm -rf target	
+    sed -i.bak -e "s|NEXUS_HOST|$nexusHost|g" $HOME/.sbt/.credentials && \
+    sed -i.bak -e "s|NEXUS_USERNAME|$nexusUsername|g" $HOME/.sbt/.credentials && \
+    sed -i.bak -e "s|NEXUS_PASSWORD|$nexusPassword|g" $HOME/.sbt/.credentials && \
+    rm $HOME/.sbt/.credentials.bak && \
+    cd /tmp && \
+    /tmp/set_sbt_proxy.sh
+
+RUN sbt new scala/scala-seed.g8 --name="scala-test" && \
+    cd scala-test && \
+    sbt test && \
+    rm -rf /tmp/scala-test /tmp/target
 
 RUN	\
-    chgrp -R 0 /usr/share && \
-    chmod -R g=u /usr/share && \
     chgrp -R 0 $HOME && \
     chmod -R 777 $HOME && \
 	chown -R 1001 $HOME
-	  
+
 USER 1001

--- a/common/jenkins-slaves/scala/docker/contrib/bin/scl_enable
+++ b/common/jenkins-slaves/scala/docker/contrib/bin/scl_enable
@@ -1,3 +1,0 @@
-# This will make scl collection binaries work out of box.
-unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-nodejs6

--- a/common/jenkins-slaves/scala/docker/contrib/bin/scl_enable.rhel7
+++ b/common/jenkins-slaves/scala/docker/contrib/bin/scl_enable.rhel7
@@ -1,2 +1,0 @@
-# This will make scl collection binaries work out of box.
-true

--- a/common/jenkins-slaves/scala/docker/sbtconfig/credentials.sbt
+++ b/common/jenkins-slaves/scala/docker/sbtconfig/credentials.sbt
@@ -1,1 +1,1 @@
-credentials += Credentials(new File("/home/jenkins/.sbt/credentials"))
+credentials += Credentials(new File("/home/jenkins/.sbt/.credentials"))

--- a/common/jenkins-slaves/scala/docker/sbtconfig/sbtopts
+++ b/common/jenkins-slaves/scala/docker/sbtconfig/sbtopts
@@ -17,15 +17,15 @@
 
 # Path to shared boot directory (default: ~/.sbt/boot in 0.11 series)
 #
--sbt-boot /home/jenkins/.sbt/boot  
+#-sbt-boot ~/.sbt/boot
 
 # Path to local Ivy repository (default: ~/.ivy2)
 #
--ivy /home/jenkins/.ivy2
+#-ivy ~/.ivy2
 
 # set memory options
 #
-#-mem   <integer>  
+#-mem   <integer>
 
 # Use local caches for projects, no sharing.
 #
@@ -40,13 +40,13 @@
 
 # Scala version (default: latest release)
 #
-#-scala-home <path>        
+#-scala-home <path>
 #-scala-version <version>
 
 # java version (default: java from PATH, currently $(java -version |& grep version))
 #
 #-java-home <path>
 
--Dsbt.override.build.repos=true 
--Dsbt.boot.credentials=/home/jenkins/.sbt/credentials 
--Dsbt.repository.config=/home/jenkins/.sbt/repositories
+-Duser.home=/home/jenkins
+-Dsbt.override.build.repos=true
+-Dsbt.boot.credentials=~/.sbt/.credentials

--- a/common/jenkins-slaves/scala/docker/set_sbt_proxy.sh
+++ b/common/jenkins-slaves/scala/docker/set_sbt_proxy.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+if [[ $HTTP_PROXY != "" ]]; then
+    echo "Setting proxy settings for sbt ..."
+
+    SBT_CONFIG=/etc/sbt/sbtopts
+    
+    proxy=$(echo $HTTP_PROXY | sed -e "s|https://||g" | sed -e "s|http://||g")
+	proxy_hostp=$(echo $proxy | cut -d "@" -f2)
+    proxy_host=$(echo $proxy_hostp | cut -d ":" -f1)
+    proxy_port=$(echo $proxy_hostp | cut -d ":" -f2)
+    proxy_userp=$(echo $proxy | cut -d "@" -f1)
+
+    echo "-Dhttp.proxyHost=\"$proxy_host\"" >> $SBT_CONFIG
+    echo "-Dhttps.proxyHost=\"$proxy_host\"" >> $SBT_CONFIG
+    
+    echo "-Dhttp.proxyPort=\"$proxy_port\"" >> $SBT_CONFIG
+    echo "-Dhttps.proxyPort=\"$proxy_port\"" >> $SBT_CONFIG
+
+    if [[ $proxy_userp != $proxy_hostp ]]; then
+        proxy_user=$(echo $proxy_userp | cut -d ":" -f1)
+        proxy_pw=$(echo $proxy_userp | sed -e "s|$proxy_user:||g")
+
+        echo "-Dhttp.proxyUser=\"$proxy_user\"" >> $SBT_CONFIG
+        echo "-Dhttps.proxyUser=\"$proxy_user\"" >> $SBT_CONFIG
+        
+        echo "-Dhttp.proxyPassword=\"$proxy_pw\"" >> $SBT_CONFIG
+        echo "-Dhttps.proxyPassword=\"$proxy_pw\"" >> $SBT_CONFIG
+    fi
+else 
+    echo "No HTTP_PROXY set. Do nothing for sbt proxy settings."
+fi
+
+if [[ $NO_PROXY != "" ]]; then
+    noproxy_host=$(echo $NO_PROXY | sed -e 's|\,\.|\,\*\.|g')
+	noproxy_host=$(echo $noproxy_host | sed -e "s/,/|/g")
+
+    echo "-Dhttp.nonProxyHosts=\"$noproxy_host\"" >> $SBT_CONFIG
+    echo "-Dhttps.nonProxyHosts=\"$noproxy_host\"" >> $SBT_CONFIG
+fi

--- a/common/jenkins-slaves/scala/docker/test/hw.scala
+++ b/common/jenkins-slaves/scala/docker/test/hw.scala
@@ -1,3 +1,0 @@
-object Hi {
-  def main(args: Array[String]) = println("Hi!")
-}


### PR DESCRIPTION
This PR updates the jenkins-slave-scala to use the most recent version of sbt and aligns the configuration of sbt to the current reference documentation.

Furthermore http proxy configuration is now adapted to the style it is done for maven and gradle (i.e. a dedicated set_sbt_proxy.sh script that modifies sbtopts to contain the needed -D java settings).

Resolves #323 