### PR TITLE
Select x86_64 architecture specifically

### DIFF
--- a/common/jenkins-agents/maven/docker/Dockerfile
+++ b/common/jenkins-agents/maven/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN yum install -y wget && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum clean all -y && \
     mkdir -p $HOME/.m2 && \
-    exactVersion=$(ls -lah /usr/lib/jvm | grep java-11-openjdk-11 | awk '{print $NF}' | head -1) && \
+    exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1) && \
     alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java && \
     alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac && \
     java -version && \


### PR DESCRIPTION
Opposed to v3.11.219 and earlier,
registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11.232
installs Java 11 already (both i386 and x86_64). The selection needs to
target x86_64 to work with both base images (otherwise i386 appears first in the list).

Fixes #354.