### PR TITLE
Remove deprecated dockerImageRepository field

### DIFF
--- a/be-fe-mono-repo-plain/openshift/component-template.yml
+++ b/be-fe-mono-repo-plain/openshift/component-template.yml
@@ -77,7 +77,6 @@ objects:
     metadata:
       name: '${COMPONENT}-backend'
     spec:
-      dockerImageRepository: '${COMPONENT}-backend'
       lookupPolicy:
         local: false
   - apiVersion: v1
@@ -85,7 +84,6 @@ objects:
     metadata:
       name: '${COMPONENT}-frontend'
     spec:
-      dockerImageRepository: '${COMPONENT}-frontend'
       lookupPolicy:
         local: false
   - apiVersion: v1

--- a/common/jenkins-agents/golang/ocp-config/is.yml
+++ b/common/jenkins-agents/golang/ocp-config/is.yml
@@ -10,6 +10,5 @@ objects:
     labels:
       app: jenkins-agent-golang
   spec:
-    dockerImageRepository: jenkins-agent-golang
     lookupPolicy:
       local: false

--- a/common/jenkins-agents/maven/ocp-config/is.yml
+++ b/common/jenkins-agents/maven/ocp-config/is.yml
@@ -10,6 +10,5 @@ objects:
     labels:
       app: jenkins-agent-maven
   spec:
-    dockerImageRepository: jenkins-agent-maven
     lookupPolicy:
       local: false

--- a/common/jenkins-agents/nodejs10-angular/ocp-config/is.yml
+++ b/common/jenkins-agents/nodejs10-angular/ocp-config/is.yml
@@ -10,6 +10,5 @@ objects:
     labels:
       app: jenkins-agent-nodejs10-angular
   spec:
-    dockerImageRepository: jenkins-agent-nodejs10-angular
     lookupPolicy:
       local: false

--- a/common/jenkins-agents/nodejs12/ocp-config/template.yaml
+++ b/common/jenkins-agents/nodejs12/ocp-config/template.yaml
@@ -26,7 +26,6 @@ objects:
     labels:
       app: jenkins-agent-nodejs12
   spec:
-    dockerImageRepository: jenkins-agent-nodejs12
     lookupPolicy:
       local: false
 - apiVersion: v1

--- a/common/jenkins-agents/python/ocp-config/is.yml
+++ b/common/jenkins-agents/python/ocp-config/is.yml
@@ -10,6 +10,5 @@ objects:
     labels:
       app: jenkins-agent-python
   spec:
-    dockerImageRepository: jenkins-agent-python
     lookupPolicy:
       local: false

--- a/common/jenkins-agents/scala/ocp-config/is.yml
+++ b/common/jenkins-agents/scala/ocp-config/is.yml
@@ -10,6 +10,5 @@ objects:
     labels:
       app: jenkins-agent-scala
   spec:
-    dockerImageRepository: jenkins-agent-scala
     lookupPolicy:
       local: false

--- a/common/ocp-config/component-environment/component-template.yml
+++ b/common/ocp-config/component-environment/component-template.yml
@@ -62,7 +62,6 @@ objects:
     metadata:
       name: "${COMPONENT}"
     spec:
-      dockerImageRepository: "${COMPONENT}"
       lookupPolicy:
         local: false
   - apiVersion: v1

--- a/common/ocp-config/ds-component-environment/ds-component.yml
+++ b/common/ocp-config/ds-component-environment/ds-component.yml
@@ -164,6 +164,5 @@ objects:
     metadata:
       name: "${COMPONENT}"
     spec:
-      dockerImageRepository: "${COMPONENT}"
       lookupPolicy:
         local: false

--- a/ds-ml-service/openshift/component-template.yml
+++ b/ds-ml-service/openshift/component-template.yml
@@ -117,7 +117,6 @@ objects:
     metadata:
       name: '${COMPONENT}-prediction-service'
     spec:
-      dockerImageRepository: '${COMPONENT}-prediction-service'
       lookupPolicy:
         local: false
   - apiVersion: v1
@@ -125,7 +124,6 @@ objects:
     metadata:
       name: '${COMPONENT}-training-service'
     spec:
-      dockerImageRepository: '${COMPONENT}-training-service'
       lookupPolicy:
         local: false
   - apiVersion: v1


### PR DESCRIPTION
It is not required to work. However, it has a weird side-effect: if the
name of the image stream equals a repository on DockerHub, then
automatic pull-through gets activated. Example: you provision the
be-golang-plain quickstarters with the name "golang". Now the
imagestream will be named "golang", and your DeploymentConfig points to
"golang:latest". OpenShift will pull that image from DockerHub, and
deploy it ... we certainly do not want that, so it is better to remove
this field.

The docs (https://docs.openshift.com/container-platform/4.4/rest_api/image_apis/imagestream-image-openshift-io-v1.html) say:

> dockerImageRepository is optional, if specified this stream is backed by a container repository on this server Deprecated: This field is deprecated as of v3.7 and will be removed in a future release. Specify the source for the tags to be imported in each tag via the spec.tags.from reference instead.