### PR TITLE
fix some issues with fe-ionic

### DIFF
--- a/fe-ionic/files/package.json
+++ b/fe-ionic/files/package.json
@@ -20,7 +20,7 @@
     "ionic_webpack": "./config/webpack.config.js"
   },
   "dependencies": {
-    "@angular/animation": "~8.2.14",
+    "@angular/animations": "~8.2.14",
     "@angular/common": "~8.2.14",
     "@angular/core": "~8.2.14",
     "@angular/forms": "~8.2.14",

--- a/fe-ionic/init.sh
+++ b/fe-ionic/init.sh
@@ -18,9 +18,11 @@ while [[ "$#" > 0 ]]; do case $1 in
 esac; shift; done
 
 echo "generate project"
+mkdir start_$COMPONENT
+cd start_$COMPONENT
 ionic start $COMPONENT blank --type=angular --no-deps --no-git
-
-cd $COMPONENT
+mv $COMPONENT/ ..
+cd ../$COMPONENT
 
 echo "fix nexus repo path"
 repo_path=$(echo "$GROUP" | tr . /)


### PR DESCRIPTION
This fixes some issues during provisioning of a fe-ionic quickstarter:
* ``ionic start``complains, if a project folder already exists. During provisioning ODS creates this folder right before ``fe-ionic/init.sh`` is called.
* typo in ``files/package.json`` in one of the dependencies

More issues with the fe-ionic are following up on #380