### PR TITLE
Improve prov app quickstarter

### DIFF
--- a/ods-provisioning-app/Jenkinsfile
+++ b/ods-provisioning-app/Jenkinsfile
@@ -13,8 +13,11 @@ odsQuickstarterPipeline(
     [odsComponent: 'ods-provisioning-app']
   )
 
-  // OpenShift resources cannot be created here as we do not have access to
-  // the configuration parameters. Users need to create the resources themselves
-  // from the local machine. A sample list can be found below:
-  // https://github.com/opendevstack/ods-provisioning-app/blob/master/ocp-config/ods-provisioning-app.env.sample
+  /*
+   * see templates in the ods-provisioning-app repository
+   */
+  odsQuickstarterStageCreateOpenShiftResources(
+    context,
+    [directory: "${context.targetDir}/ocp-config"]
+  )
 }

--- a/tests/ods-provisioning-app/golden/jenkins-build-stages.json
+++ b/tests/ods-provisioning-app/golden/jenkins-build-stages.json
@@ -1,0 +1,26 @@
+[
+  {
+    "stage": "odsPipeline start",
+    "status": "SUCCESS"
+  },
+  {
+    "stage": "Build and Unit Test",
+    "status": "SUCCESS"
+  },
+  {
+    "stage": "SonarQube Analysis",
+    "status": "SUCCESS"
+  },
+  {
+    "stage": "Build OpenShift Image",
+    "status": "SUCCESS"
+  },
+  {
+    "stage": "Tag created image",
+    "status": "SUCCESS"
+  },
+  {
+    "stage": "odsPipeline finished",
+    "status": "SUCCESS"
+  }
+]

--- a/tests/ods-provisioning-app/golden/jenkins-provision-stages.json
+++ b/tests/ods-provisioning-app/golden/jenkins-provision-stages.json
@@ -1,0 +1,22 @@
+[
+  {
+    "stage": "Checkout quickstarter",
+    "status": "SUCCESS"
+  },
+  {
+    "stage": "Initialize output directory",
+    "status": "SUCCESS"
+  },
+  {
+    "stage": "Fork from ODS Github",
+    "status": "SUCCESS"
+  },
+  {
+    "stage": "Create OpenShift resources",
+    "status": "SUCCESS"
+  },
+  {
+    "stage": "Push to remote",
+    "status": "SUCCESS"
+  }
+]

--- a/tests/ods-provisioning-app/golden/sonar-scan.json
+++ b/tests/ods-provisioning-app/golden/sonar-scan.json
@@ -1,0 +1,27 @@
+{
+  "key": "unitt-provapp",
+  "organization": "default-organization",
+  "name": "unitt-provapp",
+  "isFavorite": false,
+  "visibility": "public",
+  "extensions": [],
+  "qualityProfiles": [
+    {
+      "name": "Sonar way",
+      "language": "java",
+      "deleted": false
+    }
+  ],
+  "qualityGate": {
+    "key": 1,
+    "name": "Sonar way",
+    "isDefault": true
+  },
+  "breadcrumbs": [
+    {
+      "key": "unitt-provapp",
+      "name": "unitt-provapp",
+      "qualifier": "TRK"
+    }
+  ]
+}

--- a/tests/ods-provisioning-app/jenkinsfile_test.go
+++ b/tests/ods-provisioning-app/jenkinsfile_test.go
@@ -1,0 +1,127 @@
+package ods_provisioning_app
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	coreUtils "github.com/opendevstack/ods-core/tests/utils"
+	utils "github.com/opendevstack/ods-quickstarters/tests/utils"
+)
+
+func TestJenkinsFile(t *testing.T) {
+
+	values, err := utils.ReadConfiguration()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, filename, _, _ := runtime.Caller(0)
+	quickstarterPath := filepath.Dir(filename)
+	quickstarterName := filepath.Base(quickstarterPath)
+	fmt.Printf("quickstarter: %s\n", quickstarterName)
+	const componentId = "provapp"
+
+	// cleanup and create bb resources for this test
+	utils.CleanupAndCreateBitbucketProjectAndRepo(
+		quickstarterName, "unitt-"+componentId)
+
+	// run provision job for quickstarter in project's cd jenkins
+	stages, err := utils.RunJenkinsFile(
+		"ods-quickstarters",
+		values["ODS_BITBUCKET_PROJECT"],
+		values["ODS_GIT_REF"],
+		coreUtils.PROJECT_NAME,
+		fmt.Sprintf("%s/Jenkinsfile", quickstarterName),
+		coreUtils.PROJECT_NAME_CD,
+		coreUtils.EnvPair{
+			Name:  "COMPONENT_ID",
+			Value: componentId,
+		},
+		coreUtils.EnvPair{
+			Name:  "GIT_URL_HTTP",
+			Value: fmt.Sprintf("%s/%s/%s.git", values["REPO_BASE"], coreUtils.PROJECT_NAME, "unitt-"+componentId),
+		},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Printf("Provision Build for %s returned:\n%s", componentId, stages)
+
+	// verify provision jenkins stages - against golden record
+	expected, err := ioutil.ReadFile("golden/jenkins-provision-stages.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedAsString := string(expected)
+	if stages != expectedAsString {
+		t.Fatalf("Actual jenkins stages from prov run: %s don't match -golden:\n'%s'\n-jenkins response:\n'%s'",
+			componentId, expectedAsString, stages)
+	}
+
+	// run master build of provisioned quickstarter in project's cd jenkins
+	stages, err = utils.RunJenkinsFile(
+		"unitt-"+componentId,
+		coreUtils.PROJECT_NAME,
+		"master",
+		coreUtils.PROJECT_NAME,
+		"Jenkinsfile",
+		coreUtils.PROJECT_NAME_CD,
+		coreUtils.EnvPair{
+			Name:  "COMPONENT_ID",
+			Value: componentId,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Printf("Master (code) build for %s returned:\n%s", componentId, stages)
+
+	// verify run and build jenkins stages - against golden record
+	expected, err = ioutil.ReadFile("golden/jenkins-build-stages.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedAsString = string(expected)
+	if stages != expectedAsString {
+		t.Fatalf("Actual jenkins stages from build run: %s don't match -golden:\n'%s'\n-jenkins response:\n'%s'",
+			componentId, expectedAsString, stages)
+	}
+
+	// sonar scan check
+	sonarscan, err := utils.RetrieveSonarScan(
+		fmt.Sprintf("%s-%s", coreUtils.PROJECT_NAME, componentId))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify sonar scan - against golden record
+	expected, err = ioutil.ReadFile("golden/sonar-scan.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedAsString = string(expected)
+	if sonarscan != expectedAsString {
+		t.Fatalf("Actual sonar scan for run: %s doesn't match -golden:\n'%s'\n-sonar response:\n'%s'",
+			componentId, expectedAsString, sonarscan)
+	}
+
+	resourcesInTest := coreUtils.Resources{
+		Namespace:    coreUtils.PROJECT_NAME_TEST,
+		ImageTags:    []coreUtils.ImageTag{{Name: componentId, Tag: "master"}},
+		BuildConfigs: []string{componentId},
+		ImageStreams: []string{componentId},
+	}
+
+	coreUtils.CheckResources(resourcesInTest, t)
+
+}


### PR DESCRIPTION
That way, users can build the prov app image without making any manual changes.

Deployment is then handled in the central namespace.

Depends on https://github.com/opendevstack/ods-provisioning-app/pull/542.