### PR TITLE
use python rh based packages and keep rh development packages

### DIFF
--- a/common/jenkins-agents/python/docker/Dockerfile
+++ b/common/jenkins-agents/python/docker/Dockerfile
@@ -5,45 +5,42 @@ LABEL maintainer="Gerard Castillo <gerard.castillo@boehringer-ingelheim.com>"
 ARG nexusHost
 ARG nexusAuth
 
-ENV PYTHON_VERSION=3.6.10
-ENV VENV_VERSION=20.0.9
-ENV INSTALL_PKGS="yum-utils gcc make openssl-devel zlib-devel sqlite-devel"
+ENV LANGUAGE en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+ENV LC_CTYPE en_US.UTF-8
+ENV LC_MESSAGES en_US.UTF-8
+ENV PATH=/opt/rh/rh-python36/root/usr/bin${PATH:+:${PATH}} \
+    LD_LIBRARY_PATH=/opt/rh/rh-python36/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
+    MANPATH=/opt/rh/rh-python36/root/usr/share/man:$MANPATH \
+    PKG_CONFIG_PATH=/opt/rh/rh-python36/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}} \
+    XDG_DATA_DIRS="/opt/rh/rh-python36/root/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
 
-RUN set -x \
-    && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
-    && yum clean all \
-    && rm -rf /var/cache/yum/*
+# Enable rhel-server-rhscl-7-rpms repo
+RUN set -x && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum-config-manager --disable rhel-7-server-htb-rpms && \
+    yum makecache
 
-RUN cd /tmp \
-    && curl -O https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
-    && tar xzf Python-${PYTHON_VERSION}.tgz -C / \
-    && rm -rf Python-${Python_VERSION}.tgz
-
-RUN cd /Python-${PYTHON_VERSION} \
-    && ./configure \
-    && make altinstall \
-    && ln -s /Python-${PYTHON_VERSION}/python /usr/local/sbin/python3 \
-    && python3 -V \
-    && chmod a+rx /Python-${PYTHON_VERSION} \
-    && chmod a+rx /Python-${PYTHON_VERSION}/python \
-    && yum remove -y $INSTALL_PKGS
-
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" \
-    && python3 get-pip.py
+# Python 3.6
+RUN yum -y install --setopt=tsflags=nodocs yum-utils gcc make openssl-devel zlib-devel sqlite-devel postgresql-devel @development && \
+    yum -y install rh-python36 rh-python36-python-tools && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 # If defined, configure PIP with Nexus as default global index, define extra index to public pypi repo and set certs
-RUN if [ ! -z ${nexusHost} ] && [ ! -z ${nexusAuth} ]; \
+RUN pip install --upgrade pip && \
+    if [ ! -z ${nexusHost} ] && [ ! -z ${nexusAuth} ]; \
     then pip config set global.index-url https://${nexusAuth}@${nexusHost}/repository/pypi-all/simple \
         && pip config set global.trusted-host ${nexusHost} \
         && pip config set global.extra-index-url https://pypi.org/simple; \
     fi; \
-    pip config set global.cert /etc/ssl/certs/ca-bundle.crt
-
-# Upgrade PIP
-RUN pip3 install --upgrade pip \
-    && pip3 -V \
-    && pip3 install virtualenv==${VENV_VERSION}
+    pip config set global.cert /etc/ssl/certs/ca-bundle.crt && \
+    pip install virtualenv==20.0.9 setuptools==49.2.0 Cython==0.29.21 pypandoc==1.5
 
 # Enables default user to access $HOME folder
 RUN chgrp -R 0 $HOME && \
-    chmod -R g+rw $HOME
+    chmod -R a+rw $HOME && \
+    chown -R 1001 $HOME
+
+USER 1001


### PR DESCRIPTION
fixes #407
- we do not need to compile anymore python since we use RetHat based packages 👍 
- this also fixes possible airflow requirements when migrating to 3.x (users that might still use airflow they now can always keep upgrading ODS by using the python agent instead 🚀 )
- fix for 2.x will not be provided since there has not been any requirement as of today and users could always use the airflow based one