### PR TITLE
Bump typescript version

### DIFF
--- a/e2e-cypress/files/package.json
+++ b/e2e-cypress/files/package.json
@@ -25,6 +25,6 @@
     "ts-node": "^7.0.1",
     "tslint": "~5.11.0",
     "tslint-language-service": "^0.9.9",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.1"
   }
 }


### PR DESCRIPTION
Fixes #439. 

Output now:
```
INFO: Sensor TypeScript analysis [javascript] (done) | time=7537ms
INFO: Sensor JavaXmlSensor [java]
INFO: Sensor JavaXmlSensor [java] (done) | time=1ms
INFO: Sensor SonarTS [typescript]
INFO: Since SonarTS v2.0, TypeScript analysis is performed by SonarJS analyzer v6.0 or later. No TypeScript analysis is performed by SonarTS.
INFO: Sensor SonarTS [typescript] (done) | time=0ms
```

Build is still green, test run seems fine.

However, there is a warning:
```
npm WARN tslint-language-service@0.9.9 requires a peer of typescript@>= 2.3.1 < 3 but none is installed. You must install peer dependencies yourself.
```
See also https://github.com/angelozerr/tslint-language-service/issues/77.

I would still merge this as run is fine, whereas previously we had an exception in the log output, even though the build finished successfully as well.
