### PR TITLE
Add health check for Go quickstarter

### DIFF
--- a/be-golang-plain/Jenkinsfile
+++ b/be-golang-plain/Jenkinsfile
@@ -21,7 +21,7 @@ odsQuickstarterPipeline(
 
   odsQuickstarterStageCreateOpenShiftResources(
     context,
-    [directory: 'common/ocp-config/component-environment']
+    [directory: 'common/ocp-config/component']
   )
 
   odsQuickstarterStageRenderJenkinsfile(context)

--- a/be-golang-plain/files/main.go
+++ b/be-golang-plain/files/main.go
@@ -11,5 +11,9 @@ func main() {
 		fmt.Fprintln(w, "Hello, world!")
 	})
 
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "OK")
+	})
+
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/common/ocp-config/component/Tailorfile
+++ b/common/ocp-config/component/Tailorfile
@@ -1,0 +1,3 @@
+svc,dc,is,bc
+
+preserve bc:/spec/output/to/name,bc:/spec/output/imageLabels

--- a/common/ocp-config/component/template.yml
+++ b/common/ocp-config/component/template.yml
@@ -1,0 +1,195 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: component-template
+  app: "${PROJECT}-${COMPONENT}"
+parameters:
+- name: PROJECT
+  displayName: Application
+  description: The name of the application project.
+  required: true
+- name: COMPONENT
+  displayName: Component
+  description: The name of the application component.
+  required: true
+- name: ENV
+  displayName: Environment
+  description: The environment stage.
+  required: true
+- name: MEMORY_LIMIT
+  displayName: Memory Limit
+  description: Maximum amount of memory available for the container.
+  value: 256Mi
+- name: MEMORY_REQUEST
+  displayName: Memory Request
+  description: Minimum amount of memory requested for the container.
+  value: 128Mi
+- name: CPU_LIMIT
+  displayName: CPU Limit
+  description: Maximum CPU (milli) cores available for the container.
+  value: 100m
+- name: CPU_REQUEST
+  displayName: CPU Request
+  description: Minimum CPU (milli) cores requested for the container.
+  value: 50m
+- name: TAGVERSION
+  displayName: tag version
+  description: The version to be used.
+  value: latest
+  required: true
+- name: COMPLETION_DEADLINE_SECONDS
+  displayName: Completion Deadline Seconds
+  description: how long the docker build of the component can last before it is canceled
+  value: "1800"
+- name: READINESS_PATH
+  description: Path for readiness probe
+  value: /health
+- name: READINESS_INITIAL_DELAY
+  description: Initial delay of readiness probe in seconds
+  value: "3"
+- name: READINESS_PERIOD
+  description: Period of readiness probe in seconds
+  value: "10"
+- name: READINESS_TIMEOUT
+  description: Timeout of readiness probe in seconds
+  value: "3"
+- name: LIVENESS_PATH
+  description: Path for liveness probe
+  value: /health
+- name: LIVENESS_INITIAL_DELAY
+  description: Initial delay of liveness probe in seconds
+  value: "6"
+- name: LIVENESS_PERIOD
+  description: Period of liveness probe in seconds
+  value: "10"
+- name: LIVENESS_TIMEOUT
+  description: Timeout of liveness probe in seconds
+  value: "3"
+- name: PORT
+  description: Port of service / container
+  value: "8080"
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: "${COMPONENT}"
+  spec:
+    ports:
+      - name: ${PORT}-tcp
+        port: "${{PORT}}"
+        protocol: TCP
+        targetPort: "${{PORT}}"
+    selector:
+      app: "${PROJECT}-${COMPONENT}"
+      deploymentconfig: "${COMPONENT}"
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: "${COMPONENT}"
+  spec:
+    lookupPolicy:
+      local: false
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: ${COMPONENT}
+  spec:
+    completionDeadlineSeconds: "${{COMPLETION_DEADLINE_SECONDS}}"
+    failedBuildsHistoryLimit: 5
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${COMPONENT}:${TAGVERSION}
+    postCommit: {}
+    resources: {}
+    runPolicy: Serial
+    source:
+      type: Binary
+      binary: {}
+    strategy:
+      type: Docker
+      dockerStrategy: {}
+    successfulBuildsHistoryLimit: 5
+    triggers: []
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: "${COMPONENT}"
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      app: "${PROJECT}-${COMPONENT}"
+      deploymentconfig: "${COMPONENT}"
+    strategy:
+      activeDeadlineSeconds: 21600
+      resources: {}
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: "${PROJECT}-${COMPONENT}"
+          deploymentconfig: "${COMPONENT}"
+      spec:
+        containers:
+          - image: "${PROJECT}-${ENV}/${COMPONENT}:${TAGVERSION}"
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: "${LIVENESS_PATH}"
+                port: "${{PORT}}"
+                scheme: HTTP
+              initialDelaySeconds: "${{LIVENESS_INITIAL_DELAY}}"
+              periodSeconds: "${{LIVENESS_PERIOD}}"
+              successThreshold: 1
+              timeoutSeconds: "${{LIVENESS_TIMEOUT}}"
+            name: "${COMPONENT}"
+            ports:
+              - containerPort: "${{PORT}}"
+                protocol: TCP
+            readinessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: "${READINESS_PATH}"
+                port: "${{PORT}}"
+                scheme: HTTP
+              initialDelaySeconds: "${{READINESS_INITIAL_DELAY}}"
+              periodSeconds: "${{READINESS_PERIOD}}"
+              successThreshold: 1
+              timeoutSeconds: "${{READINESS_TIMEOUT}}"
+            resources:
+              limits:
+                cpu: "${CPU_LIMIT}"
+                memory: "${MEMORY_LIMIT}"
+              requests:
+                cpu: "${CPU_REQUEST}"
+                memory: "${MEMORY_REQUEST}"
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+      - type: ConfigChange
+      - imageChangeParams:
+          automatic: true
+          containerNames:
+            - "${COMPONENT}"
+          from:
+            kind: ImageStreamTag
+            name: "${COMPONENT}:${TAGVERSION}"
+            namespace: "${PROJECT}-${ENV}"
+        type: ImageChange


### PR DESCRIPTION
Closes #137.

`common/ocp-config/component` is basically a copy of `common/ocp-config/component-environment`, with two changes:

* removed `env: ${ENV}` label from the pod template (it's not needed)
* added readiness probe (partially parameterised but with defaults)

The idea would be that every quickstarter migrates to this template now so that eventually we can remove `common/ocp-config/component-environment`.
