### PR TITLE
Fix Ionic test results not showing - #451

### DIFF
--- a/fe-ionic/init.sh
+++ b/fe-ionic/init.sh
@@ -65,8 +65,7 @@ read -r -d "" UNIT_XML_CONFIG << EOM || true
     junitReporter: {\\
       outputDir: './build/test-results/test',\\
       outputFile: 'test-results.xml',\\
-      useBrowserName: false,\\
-      xmlVersion: 1\\
+      useBrowserName: false\\
     },
 EOM
 sed -i "s|\s*reporters: \['progress', 'kjhtml'\],|$UNIT_XML_CONFIG|" ./karma.conf.js

--- a/fe-ionic/testdata/steps.yml
+++ b/fe-ionic/testdata/steps.yml
@@ -12,6 +12,7 @@ steps:
       runAttachments:
       - SCRR-{{.ProjectID}}-{{.ComponentID}}.docx
       - SCRR-{{.ProjectID}}-{{.ComponentID}}.md
+      testResults: 3
       openShiftResources:
         imageTags:
         - name: "{{.ComponentID}}"


### PR DESCRIPTION
xmlVersion should not be used with new version of Karma junit exporter - #451

With new version of Karma this xmlVersion is no longer needed. If specified it creates format different to the one described in junit.xsd template.

Closes #451 
Fixes #451 

