### PR TITLE
Allow to write to GOPATH (3.x)

### DIFF
--- a/common/jenkins-agents/golang/docker/Dockerfile
+++ b/common/jenkins-agents/golang/docker/Dockerfile
@@ -20,4 +20,6 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
 
 RUN go get -u github.com/jstemmer/go-junit-report
 
+RUN mkdir -p /home/jenkins/go && chmod g+w /home/jenkins/go
+
 WORKDIR /go


### PR DESCRIPTION
Otherwise dependencies need to be vendored or configued to be stored in a different directory.