### PR TITLE
Fixed bug in multi-line training scripts

### DIFF
--- a/ds-ml-service/files/src/mlservice/services/infrastructure/remote/ssh/executors.py
+++ b/ds-ml-service/files/src/mlservice/services/infrastructure/remote/ssh/executors.py
@@ -135,13 +135,18 @@ mkdir {0}""".strip().format(self._target_folder),
         """
         # remote training with remote dvc repository
         if self._dvc_remote:
-            train_script = """{0}/services/infrastructure/remote/scripts/remote_trainer.py --env {0}
-            --debug {1} --dvc_remote {2} --dvc_user {3} --dvc_password {4}""". \
+            train_script = """{0}/services/infrastructure/remote/scripts/remote_trainer.py \\
+                --env {0} \\
+                --debug {1} \\
+                --dvc_remote {2} \\
+                --dvc_user {3} \\
+                --dvc_password {4}""". \
                 strip().format(self._target_folder, self._debug_mode, self._dvc_remote,
                                self._dvc_user, self._dvc_password)
         else:
-            train_script = """{0}/services/infrastructure/remote/scripts/remote_trainer.py --env {0}
-            --debug {1}""".strip().\
+            train_script = """{0}/services/infrastructure/remote/scripts/remote_trainer.py \\
+                --env {0} \\
+                --debug {1}""".strip().\
                 format(self._target_folder, self._debug_mode)
 
         result = self._connection.run(


### PR DESCRIPTION
### This PR concerns the ds_ml_service

I encountered an issue when training on a remote machine. The problem is that the mulit-line scripts in `/ods-quickstarters/ds-ml-service/files/src/mlservice/services/infrastructure/remote/ssh/executors.py`  is broken, such that only the first statement is executed. This had the effect that command line parameters were not passed to the training script.

I fixed the scripts in the `run_training` method by adding a **\\\\** add the end of each line.
