### PR TITLE
be-python-flask Dockerfile make work COPY in any case and LABEL cleanup

### DIFF
--- a/be-python-flask/files/docker/Dockerfile
+++ b/be-python-flask/files/docker/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.8-buster
 
-LABEL maintainer="Andras Gyacsok <andras.gyacsok@boehringer-ingelheim.com>"
-
 ARG nexusHostWithBasicAuth
 ARG nexusHostWithoutScheme
+
+RUN mkdir -p /app
 
 WORKDIR /app
 


### PR DESCRIPTION
When building be-python-flask Dockerfile in OpenShift4 the COPY command as is does not work anymore since the /app folder is not there and either not created automatically.

This is a minor change and does keep backwards compatibility.

We also took the chance to cleanup the LABEL attribute as done already in other quickstarters.

Tasks: 
- [x] Updated documentation in `docs/modules/...` directory
- [x] Ran tests in `<quickstarter>/testdata` directory
