### PR TITLE
Enable printing of test evidence for Spock/Geb

### DIFF
--- a/e2e-spock-geb/files/src/test/resources/SpecHelper.groovy
+++ b/e2e-spock-geb/files/src/test/resources/SpecHelper.groovy
@@ -30,10 +30,12 @@ class SpecHelper {
         return properties
     }
 
+    // prints contents of a page fragment and its children with additional metadata to stdout
     public static void printEvidenceForPageElement(GebReportingSpec spec, int testStepNumber, Class page, Navigator fragment, String description = '', int desiredLevel = -1) {
         printEvidenceForPageElements(spec, testStepNumber, page, [ [ 'fragment' : fragment, 'description' :  description] ], desiredLevel)
     }
 
+    // prints contents of a multiple page fragments and their children with additional metadata to stdout
     public static void printEvidenceForPageElements(GebReportingSpec spec, int testStepNumber, Class page, List<Map> fragmentsAndDiscriptions, int desiredLevel = -1) {
         println '====================================='
         println "Test Case: ${spec.specificationContext.currentIteration.name}"

--- a/e2e-spock-geb/files/src/test/resources/SpecHelper.groovy
+++ b/e2e-spock-geb/files/src/test/resources/SpecHelper.groovy
@@ -1,3 +1,6 @@
+import geb.navigator.Navigator
+import geb.spock.GebReportingSpec
+
 import java.util.regex.Pattern
 
 class SpecHelper {
@@ -24,5 +27,61 @@ class SpecHelper {
         }
 
         return properties
+    }
+
+    public static void printEvidenceForPageElement(GebReportingSpec spec, int testStepNumber, Navigator fragment, String description = '', int desiredLevel = -1) {
+        printEvidenceForPageElements(spec, testStepNumber, [ [ 'fragment' : fragment, 'description' :  description] ], desiredLevel)
+    }
+
+    public static void printEvidenceForPageElements(GebReportingSpec spec, int testStepNumber, List<Map> fragmentsAndDiscriptions, int desiredLevel = -1) {
+        println '====================================='
+        println "Test Case: ${spec.specificationContext.currentIteration.name}"
+        println "Test Step: ${testStepNumber}"
+
+        if (!fragmentsAndDiscriptions || fragmentsAndDiscriptions.isEmpty()) {
+            throw new IllegalArgumentException("Error: evidence fragment is empty!")
+        }
+
+        println "----- Test Evidence STARTS Here -----"
+        fragmentsAndDiscriptions.each { fragmentAndDescription ->
+            println "Description: ${fragmentAndDescription.description}"
+            printEvidenceRecursive(fragmentAndDescription.fragment, 0, desiredLevel)
+        }
+        println "----- Test Evidence ENDS Here -----"
+    }
+
+    private static printEvidenceRecursive(Navigator fragment, int level = 0, int desiredLevel = -1) {
+        if (!fragment) {
+            return
+        }
+
+        if (level == desiredLevel) {
+            return
+        }
+
+        // create fragmentIndentation based on level
+        String fragmentIndentation = ''
+        for (int i = 0; i < level; i++) {
+            fragmentIndentation += '   '
+        }
+
+        // create the prepend for the fragment, current level, plus strings
+        String fragmentPrepend = "(${level})${fragmentIndentation}"
+
+        Navigator children = fragment.children();
+        // no children of current fragment - print fragment and content
+        // (value for input types, text or for images or links, nothing)
+        if (children.size() == 0) {
+            def value = fragment.value() ?: fragment.text()
+            println "${fragmentPrepend}${fragment} ${value}"
+        } else {
+            // print the current fragment without any content
+            println "${fragmentPrepend}${fragment}"
+
+            // for each child print the evidence recursively
+            children.each { child ->
+                printEvidenceRecursive(child, (level + 1), desiredLevel)
+            }
+        }
     }
 }

--- a/e2e-spock-geb/files/src/test/resources/SpecHelper.groovy
+++ b/e2e-spock-geb/files/src/test/resources/SpecHelper.groovy
@@ -1,3 +1,4 @@
+import geb.Page
 import geb.navigator.Navigator
 import geb.spock.GebReportingSpec
 
@@ -29,14 +30,15 @@ class SpecHelper {
         return properties
     }
 
-    public static void printEvidenceForPageElement(GebReportingSpec spec, int testStepNumber, Navigator fragment, String description = '', int desiredLevel = -1) {
-        printEvidenceForPageElements(spec, testStepNumber, [ [ 'fragment' : fragment, 'description' :  description] ], desiredLevel)
+    public static void printEvidenceForPageElement(GebReportingSpec spec, int testStepNumber, Class page, Navigator fragment, String description = '', int desiredLevel = -1) {
+        printEvidenceForPageElements(spec, testStepNumber, page, [ [ 'fragment' : fragment, 'description' :  description] ], desiredLevel)
     }
 
-    public static void printEvidenceForPageElements(GebReportingSpec spec, int testStepNumber, List<Map> fragmentsAndDiscriptions, int desiredLevel = -1) {
+    public static void printEvidenceForPageElements(GebReportingSpec spec, int testStepNumber, Class page, List<Map> fragmentsAndDiscriptions, int desiredLevel = -1) {
         println '====================================='
         println "Test Case: ${spec.specificationContext.currentIteration.name}"
         println "Test Step: ${testStepNumber}"
+        println "Page URL: ${page.newInstance().pageUrl}"
 
         if (!fragmentsAndDiscriptions || fragmentsAndDiscriptions.isEmpty()) {
             throw new IllegalArgumentException("Error: evidence fragment is empty!")


### PR DESCRIPTION
Implements convenience methods for printing test evidence using the Spock/Geb quickstarter. Examples are:

1) Prints contents of the page fragment (and its children) identified by the `#numItemsInCart` CSS selector on the `CataloguePage`, and additional metadata to stdout.

```
SpecHelper.printEvidenceForPageElement(this, 1, CataloguePage, $("#numItemsInCart"), "empty cart")
```

2) Prints contents of multiple page fragments (and their children) identified by the `#username` and `#password` CSS selectors on the `HomePage`, and additional metadata to stdout.

```
SpecHelper.printEvidenceForPageElements(this, 1, HomePage, [ 
    ['fragment' : $("#username"), 'description' : 'username value'], 
    ['fragment' : $("#password"), 'description' : 'password value']
])
```

Closes #486.