### PR TITLE
fix handover of sourcMap parameter (3.x)

### DIFF
--- a/fe-angular/Jenkinsfile.template
+++ b/fe-angular/Jenkinsfile.template
@@ -25,7 +25,7 @@ def stageBuild(def context) {
       if ('master'.equals(context.gitBranch)) {
         sh "npm run build"
       } else {
-        sh "npm run build --sourceMap=true"
+        sh "npm run build -- --sourceMap=true"
       }
     }
     sh "cp -r dist/${context.componentId} docker/dist"


### PR DESCRIPTION
Like on master: The ``sourceMap`` parameter wasn't handed over properly from within Jenkinsfile for builds against non-production environments.