### PR TITLE
Add missing imports to Spock/Geb Quickstarter

### DIFF
--- a/e2e-spock-geb/files/src/test/resources/GebConfig.groovy
+++ b/e2e-spock-geb/files/src/test/resources/GebConfig.groovy
@@ -1,4 +1,5 @@
 import com.gargoylesoftware.htmlunit.BrowserVersion
+import com.gargoylesoftware.htmlunit.WebClient
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.openqa.selenium.Proxy
 


### PR DESCRIPTION
Added missing imports in GebConfig.groovy so that this code compiles correctly.
Tested in an edp box.

Closes #492 
Fixes #492 

Tasks: 
- [ ] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
