### PR TITLE
Add NodeJS10 UBI8 agent image

### DIFF
--- a/common/jenkins-agents/nodejs10-angular/docker/Dockerfile.rhel7
+++ b/common/jenkins-agents/nodejs10-angular/docker/Dockerfile.rhel7
@@ -15,7 +15,7 @@ LABEL com.redhat.component="jenkins-agent-nodejs-rhel7-docker" \
 ARG nexusUrl
 ARG nexusAuth
 
-ENV NODEJS_VERSION=8.11 \
+ENV NODEJS_VERSION=10 \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH \
     BASH_ENV=/usr/local/bin/scl_enable \

--- a/common/jenkins-agents/nodejs10-angular/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/nodejs10-angular/docker/Dockerfile.ubi8
@@ -1,0 +1,63 @@
+FROM opendevstackorg/ods-jenkins-agent-base-ubi8:latest
+
+# Labels consumed by Red Hat build service
+LABEL com.redhat.component="jenkins-agent-nodejs-12-rhel7-container" \
+      name="openshift4/jenkins-agent-nodejs-12-rhel7" \
+      architecture="x86_64" \
+      io.k8s.display-name="Jenkins Agent Nodejs" \
+      io.k8s.description="The jenkins agent nodejs image has the nodejs tools on top of the jenkins slave base image." \
+      io.openshift.tags="openshift,jenkins,agent,nodejs" \
+      maintainer="openshift-dev-services+jenkins@redhat.com"
+
+ARG nexusUrl
+ARG nexusAuth
+
+ENV NODEJS_VERSION=10 \
+    YARN_VERSION=1.22.5 \
+    NPM_CONFIG_PREFIX=$HOME/.npm-global \
+    PATH=$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+
+COPY contrib/bin/configure-agent /usr/local/bin/configure-agent
+
+# Generate machine ID
+RUN dbus-uuidgen > /etc/machine-id
+
+# Install Cypress dependencies
+# https://docs.cypress.io/guides/getting-started/installing-cypress.html#System-requirements
+COPY yum.repos.d/google-chrome.repo /etc/yum.repos.d/google-chrome.repo
+RUN yum repolist \
+    && yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib \
+    && yum install -y google-chrome-stable \
+    && yum clean all -y
+
+# Install NodeJS (https://rpm.nodesource.com/setup_12.x does NOT work)
+RUN INSTALL_PKGS="nodejs nodejs-nodemon make gcc-c++" && \
+    yum module enable -y nodejs:${NODEJS_VERSION} && \
+    yum install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y
+
+# Install Yarn
+# https://classic.yarnpkg.com/en/docs/install
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
+
+RUN npm config set registry=$nexusUrl/repository/npmjs/ && \
+    npm config set always-auth=true && \
+    npm config set _auth=$(echo -n $nexusAuth | base64) && \
+    npm config set email=no-reply@opendevstack.org && \
+    npm config set ca=null && \
+    npm config set strict-ssl=false && \
+    yarn config set registry $nexusUrl/repository/npmjs/ -g && \
+    npm install -g @angular/cli@8.0.1 --unsafe-perm=true --allow-root && \
+    npm install -g cypress@3.3.1 --unsafe-perm=true --allow-root > /dev/null && \
+    echo node version: $(node --version) && \
+    echo npm version: $(npm --version) && \
+    echo npx version: $(npx --version) && \
+    echo yarn version: $(yarn --version)
+
+RUN chown -R 1001:0 $HOME && \
+    chmod -R g+rw $HOME
+
+USER 1001

--- a/common/jenkins-agents/nodejs10-angular/docker/contrib/bin/configure-agent
+++ b/common/jenkins-agents/nodejs10-angular/docker/contrib/bin/configure-agent
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# extract the different element of an url into a JSON structure
+parse_url() {
+  # extract the protocol
+  proto="$(echo $1 | cut -f1 -d: )"
+  if [[ ! -z $proto ]] ; then
+    # remove the protocol
+    url="$(echo ${1/"$proto://"/})"
+    # extract the user (if any)
+    login="$(echo $url | grep @ | cut -d@ -f1)"
+    username="$(echo $login | cut -d: -f1)"
+    password="$(echo $login | cut -d: -f2)"
+    # extract the host
+    host_port="$(echo ${url/$login@/} | cut -d/ -f1) "
+    host="$(echo $host_port | cut -f1 -d:) "
+
+    # by request - try to extract the port
+    port="$(echo $host_port | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')"
+    # extract the uri (if any)
+    resource="/$(echo $url | grep / | cut -d/ -f2-)"
+  fi
+  echo -n "{ \"uri\": \"$1\" , \"url\": \"$url\" , \"proto\": \"$proto\" , \"login\": \"$login\" ,"
+  echo  " \"username\": \"$username\" , \"password\": \"$password\" , \"host\": \"$host\" , \"port\": \"$port\" }"
+}
+
+get_npm_proxy_config(){
+  local proto json
+  proto=$1
+  json=$2
+  username=$( echo $json | jq -r .username)
+  password=$( echo $json | jq -r .password)
+  host=$( echo $json | jq -r .host)
+  port=$( echo $json | jq -r .port)
+  proxy_url="$host:$port"
+
+  if [ -n "$username" -a -n "$password" ]; then
+    proxy_url="$proto://$username:$password@$proxy_url"
+  fi
+
+  echo $proxy_url
+}
+
+
+if [ -n "$http_proxy" ]; then 
+  json=$( parse_url $http_proxy )
+  proxy=$(get_npm_proxy_config http "$json")
+  npm -g config set proxy $proxy
+fi
+
+if [ -n "$https_proxy" ]; then 
+  json=$( parse_url $https_proxy )
+  proxy=$(get_npm_proxy_config https "$json")
+  npm -g config set https_proxy $proxy
+fi
+
+if [ -n "$no_proxy" ]; then 
+  npm -g config set noproxy $no_proxy 
+fi
+
+if [ -n "$NPM_MIRROR_URL" ]; then
+  npm -g config set registry "$NPM_MIRROR_URL"
+fi

--- a/common/jenkins-agents/nodejs10-angular/docker/yum.repos.d/google-chrome.repo
+++ b/common/jenkins-agents/nodejs10-angular/docker/yum.repos.d/google-chrome.repo
@@ -1,0 +1,6 @@
+[google-chrome]
+name=google-chrome
+baseurl=http://dl.google.com/linux/chrome/rpm/stable/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub

--- a/common/jenkins-agents/nodejs10-angular/ocp-config/bc.yml
+++ b/common/jenkins-agents/nodejs10-angular/ocp-config/bc.yml
@@ -17,6 +17,9 @@ parameters:
   value: latest
 - name: ODS_GIT_REF
   required: true
+- name: JENKINS_AGENT_DOCKERFILE_PATH
+  value: Dockerfile.rhel7
+  description: Dockerfile variant to use
 objects:
 - apiVersion: v1
   kind: BuildConfig
@@ -55,6 +58,7 @@ objects:
             value: ${NEXUS_URL}
           - name: nexusAuth
             value: ${NEXUS_AUTH}
+        dockerfilePath: ${JENKINS_AGENT_DOCKERFILE_PATH}
         from:
           kind: ImageStreamTag
           name: jenkins-agent-base:${ODS_IMAGE_TAG}


### PR DESCRIPTION
This uses the work done in #495, but installs NodeJS 10, because that's the version used in 3.x. We'll also backport #495 once merged.

There is no GitHub Action for this unfortunately because we install NPM packages for which we would need a running Nexus. I tested the image against the `fe-angular` quickstarter though. The new NodeJS 12 image (#495) does not install packages and therefore is tested in GitHub.