### PR TITLE
Enable repos on demand

### DIFF
--- a/common/jenkins-agents/nodejs12/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/nodejs12/docker/Dockerfile.ubi8
@@ -28,8 +28,8 @@ RUN dbus-uuidgen > /etc/machine-id
 # https://docs.cypress.io/guides/getting-started/installing-cypress.html#System-requirements
 COPY yum.repos.d/google-chrome.repo /etc/yum.repos.d/google-chrome.repo
 RUN yum repolist \
-    && yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib \
-    && yum install -y google-chrome-stable \
+    && yum install -y --enablerepo centos-baseos,centos-appstream xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib \
+    && yum install -y --enablerepo centos-baseos,centos-appstream,google-chrome google-chrome-stable \
     && yum clean all -y
 
 # Install NodeJS (https://rpm.nodesource.com/setup_12.x does NOT work)

--- a/common/jenkins-agents/nodejs12/docker/yum.repos.d/google-chrome.repo
+++ b/common/jenkins-agents/nodejs12/docker/yum.repos.d/google-chrome.repo
@@ -1,6 +1,6 @@
 [google-chrome]
 name=google-chrome
 baseurl=http://dl.google.com/linux/chrome/rpm/stable/$basearch
-enabled=1
+enabled=0
 gpgcheck=1
 gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub


### PR DESCRIPTION
In order to get as many packages as possible through the UBI repos, I'm going to disable the extra repos by default in a follow-up PR in ods-core.