### PR TITLE
add printEvidence cypress - master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 .vscode
 
 test-setup.bin
+/tests/

--- a/e2e-cypress/files/cypress-acceptance.json
+++ b/e2e-cypress/files/cypress-acceptance.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://www.example.com",
+  "baseUrl": "https://www.w3schools.com",
   "fixturesFolder": "fixtures",
   "integrationFolder": "build/tests/acceptance",
   "pluginsFile": "plugins/index.js",

--- a/e2e-cypress/files/plugins/index.js
+++ b/e2e-cypress/files/plugins/index.js
@@ -14,4 +14,10 @@
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+  on('task', {
+    log(message) {
+      console.log(message)
+      return null
+    }
+  })
 }

--- a/e2e-cypress/files/tests/acceptance/acceptance.spec.ts
+++ b/e2e-cypress/files/tests/acceptance/acceptance.spec.ts
@@ -4,7 +4,10 @@ function printEvidenceForPageElement
     throw new Error('selector must not NOT be undefined');
   }
   cy.task('log', '=====================================');
-  cy.task('log', 'Testname: ' + testName + ' // step: ' + testStep + ' // url: ' + cy.url());
+  cy.task('log', 'Testname: ' + testName + ' // step: ' + testStep);
+  cy.url().then(urlString => {
+    cy.task('log', 'URL: ' + urlString);
+  });
   cy.task('log', 'Description: ' + description);
   cy.task('log', '----- Test Evidence starts here ----');
   cy.get(selector).then(($selectedElement) => {

--- a/e2e-cypress/files/tests/acceptance/acceptance.spec.ts
+++ b/e2e-cypress/files/tests/acceptance/acceptance.spec.ts
@@ -1,5 +1,29 @@
+function printEvidenceForPageElement
+  (testName: string, testStep: number, selector: string, description: string) {
+  if (!selector) {
+    throw new Error('selector must not NOT be undefined');
+  }
+  cy.task('log', '=====================================');
+  cy.task('log', 'Testname: ' + testName + ' // step: ' + testStep + ' // url: ' + cy.url());
+  cy.task('log', 'Description: ' + description);
+  cy.task('log', '----- Test Evidence starts here ----');
+  cy.get(selector).then(($selectedElement) => {
+    cy.task('log', 'Selector: ' + selector + '\r ' +
+      $selectedElement.get(0).outerHTML);
+  });
+  cy.task('log', '----- Test Evidence ends here ----');
+}
 
 /* tslint:disable:no-unused-expression */
 describe('acceptance e2e tests', function () {
-    // see installation.spec.ts for examples
+  // see installation.spec.ts for examples
+
+  it('Application is reachable', function () {
+    cy.visit('/html/tryit.asp?filename=tryhtml_basic_paragraphs');
+    cy.title().should('include', 'Tryit Editor v3.6');
+    printEvidenceForPageElement(
+      this.test.fullTitle(), 1, '#textareaCode', 'code area');
+    printEvidenceForPageElement(
+      this.test.fullTitle(), 2, '#iframecontainer', 'rendered code area');
+  });
 });


### PR DESCRIPTION
fixes #488  - for master

current state of the union:
```
=====================================
Testname: e2e tests Application is reachable // step: 1 // url: [object Object]
Description: code area
----- Test Evidence starts here ----
Selector: #textareaCode
 <textarea autocomplete="off" id="textareaCode" wrap="logical" spellcheck="false" style="display: none;">&lt;!DOCTYPE html&gt;
&lt;html&gt;
&lt;body&gt;

&lt;p&gt;This is a paragraph.&lt;/p&gt;
&lt;p&gt;This is another paragraph.&lt;/p&gt;

&lt;/body&gt;
&lt;/html&gt;
</textarea>
----- Test Evidence ends here ----
=====================================
Testname: e2e tests Application is reachable // step: 1
URL: https://www.w3schools.com/html/tryit.asp?filename=tryhtml_basic_paragraphs
Description: rendered code area
----- Test Evidence starts here ----
Selector: #iframecontainer
 <div id="iframecontainer">
    <div id="iframe">
      <div id="iframewrapper"><iframe frameborder="0" id="iframeResult" name="iframeResult" allowfullscreen="true"></iframe></div>
    </div>
  </div>
----- Test Evidence ends here ----
```
@metmajer -fyi