### PR TITLE
change maven version for maven-agent rhel7

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -44,6 +44,23 @@ jobs:
               --build-arg nexusPassword=s3cr3t \
               .
 
+  jenkins-agent-maven-rhel7:
+    name: Jenkins agent Maven (RHEL7)
+    runs-on: ubuntu-18.04
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v2.0.0
+      -
+        name: Build docker image
+        working-directory: common/jenkins-agents/maven/docker
+        run: |
+          docker build --tag agent-maven-test-rhel7 --file Dockerfile.rhel7 \
+            --build-arg nexusUrl=https://nexus.example.com \
+            --build-arg nexusUsername=developer \
+            --build-arg nexusPassword=s3cr3t \
+            .
+
   jenkins-agent-nodejs12-rhel7:
     name: Jenkins agent NodeJS 12 (RHEL7)
     runs-on: ubuntu-18.04

--- a/common/jenkins-agents/maven/docker/Dockerfile.rhel7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.rhel7
@@ -25,11 +25,11 @@ ENV BASH_ENV=/usr/local/bin/scl_enable \
 # Install Java
 RUN yum install -y java-11-openjdk-devel && \
     yum clean all -y && \
-        exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1) && \
-        alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java && \
-        alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac && \
-        java -version && \
-        javac -version
+    exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1) && \
+    alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java && \
+    alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac && \
+    java -version && \
+    javac -version
 ENV JAVA_HOME=/usr/lib/jvm/jre
 
 # Install Maven

--- a/common/jenkins-agents/maven/docker/Dockerfile.rhel7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.rhel7
@@ -16,29 +16,34 @@ ARG nexusUrl
 ARG nexusUsername
 ARG nexusPassword
 
-ENV MAVEN_VERSION=3.3 \
-    BASH_ENV=/usr/local/bin/scl_enable \
+ENV BASH_ENV=/usr/local/bin/scl_enable \
     ENV=/usr/local/bin/scl_enable \
     PROMPT_COMMAND=". /usr/local/bin/scl_enable" \
     HOME=/home/jenkins \
     GRADLE_USER_HOME=/home/jenkins/.gradle
 
-#set JAVA_HOME
+# Install Java
+RUN yum install -y java-11-openjdk-devel && \
+    yum clean all -y && \
+        exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1) && \
+        alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java && \
+        alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac && \
+        java -version && \
+        javac -version
 ENV JAVA_HOME=/usr/lib/jvm/jre
 
 # Install Maven
-RUN yum install -y wget && \
-    wget https://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo && \
-    sed -i s/\$releasever/6/g /etc/yum.repos.d/epel-apache-maven.repo && \
-    INSTALL_PKGS="java-11-openjdk-devel apache-maven*" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    yum clean all -y && \
+ENV MAVEN_VERSION=3.5.4
+ENV BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref && \
+    curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 && \
+    rm -f /tmp/apache-maven.tar.gz && \
+    ln -s /usr/share/maven/bin/mvn /usr/bin/mvn && \
     mkdir -p $HOME/.m2 && \
-    exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1) && \
-    alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java && \
-    alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac && \
-    java -version && \
-    javac -version
+    mvn --version
+ENV MAVEN_HOME=/usr/share/maven
+ENV MAVEN_CONFIG=$HOME/.m2
 
 # Container support is now integrated in Java 11, the +UseCGroupMemoryLimitForHeap option has been pruned
 ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true"


### PR DESCRIPTION
Installs maven version 3.5.4 in the maven agent. I ran this image in a pipeline of a test project and printed the following:

```
+ java -version
Picked up JAVA_TOOL_OPTIONS: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
openjdk version "11.0.9" 2020-10-20 LTS
OpenJDK Runtime Environment 18.9 (build 11.0.9+11-LTS)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.9+11-LTS, mixed mode, sharing)
+ javac -version
Picked up JAVA_TOOL_OPTIONS: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true

javac 11.0.9
+ mvn --version
Picked up JAVA_TOOL_OPTIONS: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
Apache Maven 3.5.4 (1edded0938998edf8bf061f1ceb3cfdeccf443fe; 2018-06-17T18:33:14Z)
Maven home: /usr/share/maven
Java version: 11.0.9, vendor: Red Hat, Inc., runtime: /usr/lib/jvm/java-11-openjdk-11.0.9.11-0.el7_9.x86_64
Default locale: en_US, platform encoding: ANSI_X3.4-1968
OS name: "linux", version: "3.10.0-1062.4.2.el7.x86_64", arch: "amd64", family: "unix"
```

so it seems to work.

Closes #484 

