### PR TITLE
Read more environment variables for the QS pipeline

### DIFF
--- a/be-fe-mono-repo-plain/Jenkinsfile
+++ b/be-fe-mono-repo-plain/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-base:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-base:${agentImageTag}",
 ) { context ->
 
   odsQuickstarterStageCopyFiles(context)

--- a/be-gateway-nginx/Jenkinsfile
+++ b/be-gateway-nginx/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-base:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-base:${agentImageTag}",
 ) { context ->
 
   odsQuickstarterStageCopyFiles(context)

--- a/be-golang-plain/Jenkinsfile
+++ b/be-golang-plain/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-golang:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-golang:${agentImageTag}",
 ) { context ->
 
   odsQuickstarterStageCopyFiles(context)

--- a/be-java-springboot/Jenkinsfile
+++ b/be-java-springboot/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-maven:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-maven:${agentImageTag}",
 ) { context ->
 
   stage('Build spring project') {

--- a/be-python-flask/Jenkinsfile
+++ b/be-python-flask/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-python:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-python:${agentImageTag}",
 ) { context ->
 
   odsQuickstarterStageCopyFiles(context)

--- a/be-scala-play/Jenkinsfile
+++ b/be-scala-play/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-scala:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-scala:${agentImageTag}",
 ) { context ->
 
   stage("init scala play project") {

--- a/be-typescript-express/Jenkinsfile
+++ b/be-typescript-express/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs12:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs12:${agentImageTag}",
 ) { context ->
 
   stage("init Project") {

--- a/docker-plain/Jenkinsfile
+++ b/docker-plain/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-base:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-base:${agentImageTag}",
 ) { context ->
 
   odsQuickstarterStageCopyFiles(context)

--- a/ds-jupyter-notebook/Jenkinsfile
+++ b/ds-jupyter-notebook/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-base:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-base:${agentImageTag}",
 ) { context ->
 
   odsQuickstarterStageCopyFiles(context)

--- a/ds-ml-service/Jenkinsfile
+++ b/ds-ml-service/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-python:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-python:${agentImageTag}",
 ) { context ->
 
   odsQuickstarterStageCopyFiles(context)

--- a/ds-rshiny/Jenkinsfile
+++ b/ds-rshiny/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-base:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-base:${agentImageTag}",
 ) { context ->
 
   odsQuickstarterStageCopyFiles(context)

--- a/e2e-cypress/Jenkinsfile
+++ b/e2e-cypress/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs12:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs12:${agentImageTag}",
 ) { context ->
 
   odsQuickstarterStageCopyFiles(context)

--- a/e2e-spock-geb/Jenkinsfile
+++ b/e2e-spock-geb/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-maven:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-maven:${agentImageTag}",
 ) { context ->
 
   odsQuickstarterStageCopyFiles(context)

--- a/fe-angular/Jenkinsfile
+++ b/fe-angular/Jenkinsfile
@@ -1,13 +1,23 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 def angularCliVersion = "8.0.3"
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs12:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs12:${agentImageTag}",
 ) { context ->
 
   stage("update angular cli") {

--- a/fe-ionic/Jenkinsfile
+++ b/fe-ionic/Jenkinsfile
@@ -1,13 +1,23 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 def ionicVersion = "5.4.16"
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs12:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs12:${agentImageTag}",
 ) { context ->
 
   stage("update ionic cli") {

--- a/ods-document-gen-svc/Jenkinsfile
+++ b/ods-document-gen-svc/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-maven:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-maven:${agentImageTag}",
 ) { context ->
 
   odsQuickstarterStageForkODS(

--- a/ods-provisioning-app/Jenkinsfile
+++ b/ods-provisioning-app/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-maven:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-maven:${agentImageTag}",
 ) { context ->
 
   odsQuickstarterStageForkODS(

--- a/release-manager/Jenkinsfile
+++ b/release-manager/Jenkinsfile
@@ -1,11 +1,21 @@
-def odsNamespace = env.ODS_NAMESPACE ?: 'ods'
-def odsGitRef = env.ODS_GIT_REF ?: 'master'
-def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsNamespace = ''
+def odsGitRef = ''
+def odsImageTag = ''
+def sharedLibraryRef = ''
+def agentImageTag = ''
 
-library("ods-jenkins-shared-library@${odsGitRef}")
+node {
+  odsNamespace = env.ODS_NAMESPACE ?: 'ods'
+  odsGitRef = env.ODS_GIT_REF ?: 'master'
+  odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+  sharedLibraryRef = env.SHARED_LIBRARY_REF ?: odsImageTag
+  agentImageTag = env.AGENT_IMAGE_TAG ?: odsImageTag
+}
+
+library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-base:${odsImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-base:${agentImageTag}",
 ) { context ->
 
   odsQuickstarterStageCopyFiles(context)


### PR DESCRIPTION
* Read `SHARED_LIBRARY_REF` and `AGENT_IMAGE_TAG` if present. This is a
follow-up from https://github.com/opendevstack/ods-core/issues/773. Note
that the default Git ref changes from `master` to `latest`, but this
should be fine as the ODS installation creates this Git ref. The
component `Jenkinsfile` already points to `latest` by default.
* Read environment variables within `node` block to also pick up
defaults baked into the Jenkins master image.

Ran into this during testing for OpenShift 4 and also in tests related to https://github.com/opendevstack/ods-provisioning-app/issues/646.