### PR TITLE
Fix quickstarters

### DIFF
--- a/be-fe-mono-repo-plain/Jenkinsfile.template
+++ b/be-fe-mono-repo-plain/Jenkinsfile.template
@@ -57,10 +57,16 @@ def stageUnitTestBackend(def context) {
 }
 
 def stageTestDeployedComponents(def context, def deploymentInfo) {
+  def podName = deploymentInfo['DeploymentConfig'][context.componentId][0].podName
   stage('Test Deployed Component') {
-	sh (script : "oc port-forward ${deploymentInfo.podName} 8081 -n ${context.targetProject} &", label : "Setting up port forward for pod ${deploymentInfo.podName}")
-	// wait for port-forward to map the ports or for 10s
-	sh (script : "timeout 10s bash -c 'until ! curl -v --silent http://localhost:8081 2>&1 | grep -m 1 \"Connection refused\"; do sleep 1 ; done'; echo -e \\\\a", 
-        label : "send request to service")
+    sh(
+      script: "oc port-forward ${podName} 8081 -n ${context.targetProject} &",
+      label: "Setting up port forward for pod ${podName}"
+    )
+    // wait for port-forward to map the ports for 10s
+    sh(
+      script: "timeout 10s bash -c 'until ! curl -v --silent http://localhost:8081 2>&1 | grep -m 1 \"Connection refused\"; do sleep 1 ; done'; echo -e \\\\a",
+      label: "send request to service"
+    )
   }
 }

--- a/ds-jupyter-notebook/Jenkinsfile.template
+++ b/ds-jupyter-notebook/Jenkinsfile.template
@@ -19,8 +19,5 @@ odsComponentPipeline(
     ])
   }
 
-  // rollout auth proxy - this registers the dc for later promotion
-  odsComponentStageRolloutOpenShiftDeployment(context, [resourceName: "${context.componentId}-auth-proxy"])
-
   odsComponentStageRolloutOpenShiftDeployment(context)
 }

--- a/ds-jupyter-notebook/testdata/golden/jenkins-build-stages.json
+++ b/ds-jupyter-notebook/testdata/golden/jenkins-build-stages.json
@@ -8,10 +8,6 @@
     "status": "SUCCESS"
   },
   {
-    "stage": "Deploy to OpenShift (jupyter-auth-proxy)",
-    "status": "SUCCESS"
-  },
-  {
     "stage": "Deploy to OpenShift",
     "status": "SUCCESS"
   },

--- a/ds-ml-service/Jenkinsfile.template
+++ b/ds-ml-service/Jenkinsfile.template
@@ -27,7 +27,9 @@ odsComponentPipeline(
     buildArgs["serviceType"] = "training"
     odsComponentStageBuildOpenShiftImage(context, [resourceName: trainingServiceName, buildArgs: buildArgs])
   }
-  def trainingDeployInfo = odsComponentStageRolloutOpenShiftDeployment(context, [resourceName: trainingServiceName])
+  def trainingDeployInfo = odsComponentStageRolloutOpenShiftDeployment(
+    context, [selector: "deploymentconfig=${trainingServiceName}"]
+  )
   def trainingDeployFirstPodName = trainingDeployInfo['DeploymentConfig'][trainingServiceName][0].podName
 
   stageTrainingUnitTests(context, trainingDeployFirstPodName)
@@ -39,7 +41,9 @@ odsComponentPipeline(
     buildArgs["serviceType"] = "prediction"
     odsComponentStageBuildOpenShiftImage(context, [resourceName: predictionServiceName, buildArgs: buildArgs])
   }
-  odsComponentStageRolloutOpenShiftDeployment(context, [resourceName: predictionServiceName ])
+  odsComponentStageRolloutOpenShiftDeployment(
+    context, [selector: "deploymentconfig=${predictionServiceName}"]
+  )
 }
 
 def stageLint(def context) {

--- a/ds-ml-service/Jenkinsfile.template
+++ b/ds-ml-service/Jenkinsfile.template
@@ -28,10 +28,11 @@ odsComponentPipeline(
     odsComponentStageBuildOpenShiftImage(context, [resourceName: trainingServiceName, buildArgs: buildArgs])
   }
   def trainingDeployInfo = odsComponentStageRolloutOpenShiftDeployment(context, [resourceName: trainingServiceName])
+  def trainingDeployFirstPodName = trainingDeployInfo['DeploymentConfig'][trainingServiceName][0].podName
 
-  stageTrainingUnitTests(context, trainingDeployInfo.podName)
-  stageTraining(context, trainingDeployInfo.podName)
-  stageTrainingIntegrationTests(context, trainingDeployInfo.podName)
+  stageTrainingUnitTests(context, trainingDeployFirstPodName)
+  stageTraining(context, trainingDeployFirstPodName)
+  stageTrainingIntegrationTests(context, trainingDeployFirstPodName)
   odsComponentStageScanWithSonar(context)
 
   odsComponentStageImportOpenShiftImageOrElse(context, [resourceName: predictionServiceName]) {

--- a/ds-ml-service/openshift/component-template.yml
+++ b/ds-ml-service/openshift/component-template.yml
@@ -179,6 +179,8 @@ objects:
   - apiVersion: v1
     kind: DeploymentConfig
     metadata:
+      labels:
+        deploymentconfig: '${COMPONENT}-prediction-service'
       name: '${COMPONENT}-prediction-service'
     spec:
       replicas: 1
@@ -262,6 +264,8 @@ objects:
   - apiVersion: v1
     kind: DeploymentConfig
     metadata:
+      labels:
+        deploymentconfig: '${COMPONENT}-training-service'
       name: '${COMPONENT}-training-service'
     spec:
       replicas: 1

--- a/ds-rshiny/Jenkinsfile.template
+++ b/ds-rshiny/Jenkinsfile.template
@@ -15,8 +15,5 @@ odsComponentPipeline(
     odsComponentStageBuildOpenShiftImage(context)
   }
 
-  // rollout auth proxy - this registers the dc for later promotion
-  odsComponentStageRolloutOpenShiftDeployment(context, [resourceName: "${context.componentId}-auth-proxy"])
-
   odsComponentStageRolloutOpenShiftDeployment(context)
 }

--- a/ds-rshiny/testdata/golden/jenkins-build-stages.json
+++ b/ds-rshiny/testdata/golden/jenkins-build-stages.json
@@ -8,10 +8,6 @@
     "status": "SUCCESS"
   },
   {
-    "stage": "Deploy to OpenShift (rshiny-auth-proxy)",
-    "status": "SUCCESS"
-  },
-  {
     "stage": "Deploy to OpenShift",
     "status": "SUCCESS"
   },


### PR DESCRIPTION
https://github.com/opendevstack/ods-jenkins-shared-library/pull/514 had more impact on the quickstarters than expected:

* `ds-rshiny` and `ds-jupyter-notebook` still worked, but they were rolled out twice, which is not necessary.
* `be-fe-mono-repo-plain` used the rollout information to check the deployment. That failed because the structure changed.
* `ds-ml-service` is using a "staged approach": first build and deploy one service, then continue with the next. Now that we everything in one go that has a certain label, we need to set and target more specific labels to achieve this.

Fixes https://github.com/opendevstack/ods-jenkins-shared-library/issues/526.