### PR TITLE
Do not run yum makecache

### DIFF
--- a/common/jenkins-agents/nodejs12/docker/Dockerfile.rhel7
+++ b/common/jenkins-agents/nodejs12/docker/Dockerfile.rhel7
@@ -23,8 +23,7 @@ ENV NODEJS_VERSION=12 \
 
 # install google-chrome (for angular)
 RUN yum-config-manager --enable rhel-7-server-extras-rpms && \
-    yum-config-manager --enable rhel-7-server-optional-rpms && \
-    yum makecache
+    yum-config-manager --enable rhel-7-server-optional-rpms
 
 ADD https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm /root/google-chrome-stable_current_x86_64.rpm
 RUN yum -y install redhat-lsb libXScrnSaver


### PR DESCRIPTION
`yum makecache` leads to:

```
Error: Error writing to file /var/cache/yum/x86_64/7Server/rhel-7-server-rpms/gen/other_db.sqlite: [Errno 28] No space left on device
```

Without this command, it works.

This only affects `master`, as `3.x` does not install Chrome for `nodejs12`, see https://github.com/opendevstack/ods-quickstarters/blob/3.x/common/jenkins-agents/nodejs12/docker/Dockerfile.rhel7.
