### PR TITLE
Add example using env vars from Jenkinsfile to application.properties in Spock/Geb quickstarter

### DIFF
--- a/e2e-spock-geb/files/src/test/resources/application.properties
+++ b/e2e-spock-geb/files/src/test/resources/application.properties
@@ -1,4 +1,8 @@
 # Base url with the application to test - w3c schools
 config.application.url=https://www.w3schools.com
+
+# Base url with the application to test - OpenShift app using env vars from Jenkinsfile
+# config.application.url=http://app-${OPENSHIFT_PROJECT}.${OPENSHIFT_PUBLIC_HOST}
+
 # Reports dir
 config.reports.dir=build/geb-reports

--- a/e2e-spock-geb/files/src/test/resources/application.properties
+++ b/e2e-spock-geb/files/src/test/resources/application.properties
@@ -2,7 +2,7 @@
 config.application.url=https://www.w3schools.com
 
 # Base url with the application to test - OpenShift app using env vars from Jenkinsfile
-# config.application.url=http://app-${OPENSHIFT_PROJECT}.${OPENSHIFT_PUBLIC_HOST}
+# config.application.url=http://app-${OPENSHIFT_PROJECT}.${OPENSHIFT_APP_DOMAIN}
 
 # Reports dir
 config.reports.dir=build/geb-reports


### PR DESCRIPTION
This PR adds an example to the Spock/Geb quickstarter's `src/test/resources/application.properties` file to avoid confusion on how to inject environment variables.

Fixes https://github.com/opendevstack/ods-jenkins-shared-library/issues/540
