### PR TITLE
Remove BuildConfig and ImageStream resources

### DIFF
--- a/be-fe-mono-repo-plain/openshift/component-template.yml
+++ b/be-fe-mono-repo-plain/openshift/component-template.yml
@@ -37,10 +37,6 @@ parameters:
     description: The version to be used.
     value: latest
     required: true
-  - name: COMPLETION_DEADLINE_SECONDS
-    displayName: Completion Deadline Seconds
-    description: how long the docker build of the component can last before it is canceled
-    value: "1800"
 objects:
   - apiVersion: v1
     kind: Service
@@ -71,65 +67,7 @@ objects:
         app: '${PROJECT}-${COMPONENT}'
         deploymentconfig: '${COMPONENT}'
       sessionAffinity: None
-      type: ClusterIP      
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      name: '${COMPONENT}-backend'
-    spec:
-      lookupPolicy:
-        local: false
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      name: '${COMPONENT}-frontend'
-    spec:
-      lookupPolicy:
-        local: false
-  - apiVersion: v1
-    kind: BuildConfig
-    metadata:
-      name: ${COMPONENT}-frontend
-    spec:
-      completionDeadlineSeconds: "${{COMPLETION_DEADLINE_SECONDS}}"
-      failedBuildsHistoryLimit: 5
-      nodeSelector: null
-      output:
-        to:
-          kind: ImageStreamTag
-          name: ${COMPONENT}-frontend:${TAGVERSION}
-      postCommit: {}
-      resources: {}
-      runPolicy: Serial
-      source:
-        type: Binary
-        binary: {}
-      strategy:
-        type: Docker
-        dockerStrategy: {}
-      successfulBuildsHistoryLimit: 5
-  - apiVersion: v1
-    kind: BuildConfig
-    metadata:
-      name: ${COMPONENT}-backend
-    spec:
-      completionDeadlineSeconds: "${{COMPLETION_DEADLINE_SECONDS}}"
-      failedBuildsHistoryLimit: 5
-      nodeSelector: null
-      output:
-        to:
-          kind: ImageStreamTag
-          name: ${COMPONENT}-backend:${TAGVERSION}
-      postCommit: {}
-      resources: {}
-      runPolicy: Serial
-      source:
-        type: Binary
-        binary: {}
-      strategy:
-        type: Docker
-        dockerStrategy: {}
-      successfulBuildsHistoryLimit: 5
+      type: ClusterIP
   - apiVersion: v1
     kind: DeploymentConfig
     metadata:

--- a/be-fe-mono-repo-plain/testdata/steps.yml
+++ b/be-fe-mono-repo-plain/testdata/steps.yml
@@ -14,9 +14,6 @@ steps:
           tag: latest
         - name: "{{.ComponentID}}-frontend"
           tag: latest
-        buildConfigs:
-        - "{{.ComponentID}}-backend"
-        - "{{.ComponentID}}-frontend"
         imageStreams:
         - "{{.ComponentID}}-backend"
         - "{{.ComponentID}}-frontend"

--- a/be-gateway-nginx/testdata/steps.yml
+++ b/be-gateway-nginx/testdata/steps.yml
@@ -12,8 +12,6 @@ steps:
         imageTags:
         - name: "{{.ComponentID}}"
           tag: latest
-        buildConfigs:
-        - "{{.ComponentID}}"
         imageStreams:
         - "{{.ComponentID}}"
         deploymentConfigs:

--- a/be-golang-plain/testdata/steps.yml
+++ b/be-golang-plain/testdata/steps.yml
@@ -17,8 +17,6 @@ steps:
         imageTags:
         - name: "{{.ComponentID}}"
           tag: latest
-        buildConfigs:
-        - "{{.ComponentID}}"
         imageStreams:
         - "{{.ComponentID}}"
         deploymentConfigs:

--- a/be-java-springboot/testdata/steps.yml
+++ b/be-java-springboot/testdata/steps.yml
@@ -17,8 +17,6 @@ steps:
         imageTags:
         - name: "{{.ComponentID}}"
           tag: latest
-        buildConfigs:
-        - "{{.ComponentID}}"
         imageStreams:
         - "{{.ComponentID}}"
         deploymentConfigs:

--- a/be-python-flask/testdata/steps.yml
+++ b/be-python-flask/testdata/steps.yml
@@ -17,8 +17,6 @@ steps:
         imageTags:
         - name: "{{.ComponentID}}"
           tag: latest
-        buildConfigs:
-        - "{{.ComponentID}}"
         imageStreams:
         - "{{.ComponentID}}"
         deploymentConfigs:

--- a/be-scala-play/testdata/steps.yml
+++ b/be-scala-play/testdata/steps.yml
@@ -17,8 +17,6 @@ steps:
         imageTags:
         - name: "{{.ComponentID}}"
           tag: latest
-        buildConfigs:
-        - "{{.ComponentID}}"
         imageStreams:
         - "{{.ComponentID}}"
         deploymentConfigs:

--- a/be-typescript-express/testdata/steps.yml
+++ b/be-typescript-express/testdata/steps.yml
@@ -17,8 +17,6 @@ steps:
         imageTags:
         - name: "{{.ComponentID}}"
           tag: latest
-        buildConfigs:
-        - "{{.ComponentID}}"
         imageStreams:
         - "{{.ComponentID}}"
         deploymentConfigs:

--- a/common/ocp-config/component-environment/component-template.yml
+++ b/common/ocp-config/component-environment/component-template.yml
@@ -37,10 +37,6 @@ parameters:
     description: The version to be used.
     value: latest
     required: true
-  - name: COMPLETION_DEADLINE_SECONDS
-    displayName: Completion Deadline Seconds
-    description: how long the docker build of the component can last before it is canceled
-    value: "1800"
 objects:
   - apiVersion: v1
     kind: Service
@@ -57,35 +53,6 @@ objects:
         deploymentconfig: "${COMPONENT}"
       sessionAffinity: None
       type: ClusterIP
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      name: "${COMPONENT}"
-    spec:
-      lookupPolicy:
-        local: false
-  - apiVersion: v1
-    kind: BuildConfig
-    metadata:
-      name: ${COMPONENT}
-    spec:
-      completionDeadlineSeconds: "${{COMPLETION_DEADLINE_SECONDS}}"
-      failedBuildsHistoryLimit: 5
-      nodeSelector: null
-      output:
-        to:
-          kind: ImageStreamTag
-          name: ${COMPONENT}:${TAGVERSION}
-      postCommit: {}
-      resources: {}
-      runPolicy: Serial
-      source:
-        type: Binary
-        binary: {}
-      strategy:
-        type: Docker
-        dockerStrategy: {}
-      successfulBuildsHistoryLimit: 5
   - apiVersion: v1
     kind: DeploymentConfig
     metadata:

--- a/common/ocp-config/component/template.yml
+++ b/common/ocp-config/component/template.yml
@@ -37,10 +37,6 @@ parameters:
   description: The version to be used.
   value: latest
   required: true
-- name: COMPLETION_DEADLINE_SECONDS
-  displayName: Completion Deadline Seconds
-  description: how long the docker build of the component can last before it is canceled
-  value: "1800"
 - name: READINESS_PATH
   description: Path for readiness probe
   value: /health
@@ -84,35 +80,6 @@ objects:
       deploymentconfig: "${COMPONENT}"
     sessionAffinity: None
     type: ClusterIP
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: "${COMPONENT}"
-  spec:
-    lookupPolicy:
-      local: false
-- apiVersion: v1
-  kind: BuildConfig
-  metadata:
-    name: ${COMPONENT}
-  spec:
-    completionDeadlineSeconds: "${{COMPLETION_DEADLINE_SECONDS}}"
-    failedBuildsHistoryLimit: 5
-    nodeSelector: null
-    output:
-      to:
-        kind: ImageStreamTag
-        name: ${COMPONENT}:${TAGVERSION}
-    postCommit: {}
-    resources: {}
-    runPolicy: Serial
-    source:
-      type: Binary
-      binary: {}
-    strategy:
-      type: Docker
-      dockerStrategy: {}
-    successfulBuildsHistoryLimit: 5
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:

--- a/common/ocp-config/ds-component-environment/ds-component.yml
+++ b/common/ocp-config/ds-component-environment/ds-component.yml
@@ -63,28 +63,6 @@ objects:
       type: ClusterIP
 
   - apiVersion: v1
-    kind: BuildConfig
-    metadata:
-      name: ${COMPONENT}
-    spec:
-      failedBuildsHistoryLimit: 5
-      nodeSelector: null
-      output:
-        to:
-          kind: ImageStreamTag
-          name: ${COMPONENT}:${TAGVERSION}
-      postCommit: {}
-      resources: {}
-      runPolicy: Serial
-      source:
-        type: Binary
-        binary: {}
-      strategy:
-        type: Docker
-        dockerStrategy: {}
-      successfulBuildsHistoryLimit: 5
-
-  - apiVersion: v1
     kind: DeploymentConfig
     metadata:
       creationTimestamp: null
@@ -158,10 +136,3 @@ objects:
               namespace: ${PROJECT}-${ENV}
           type: ImageChange
     status: {}
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      name: "${COMPONENT}"
-    spec:
-      lookupPolicy:
-        local: false

--- a/docker-plain/testdata/steps.yml
+++ b/docker-plain/testdata/steps.yml
@@ -12,8 +12,6 @@ steps:
         imageTags:
         - name: "{{.ComponentID}}"
           tag: latest
-        buildConfigs:
-        - "{{.ComponentID}}"
         imageStreams:
         - "{{.ComponentID}}"
         deploymentConfigs:

--- a/ds-jupyter-notebook/testdata/steps.yml
+++ b/ds-jupyter-notebook/testdata/steps.yml
@@ -12,8 +12,6 @@ steps:
         imageTags:
         - name: "{{.ComponentID}}"
           tag: latest
-        buildConfigs:
-        - "{{.ComponentID}}"
         imageStreams:
         - "{{.ComponentID}}"
         deploymentConfigs:

--- a/ds-ml-service/openshift/component-template.yml
+++ b/ds-ml-service/openshift/component-template.yml
@@ -37,10 +37,6 @@ parameters:
     description: The version to be used.
     value: latest
     required: true
-  - name: COMPLETION_DEADLINE_SECONDS
-    displayName: Completion Deadline Seconds
-    description: how long the docker build of the component can last before it is canceled
-    value: "1800"
   - name: TRAINING_USERNAME
     description: Username for training service
     displayName: Training service username
@@ -112,70 +108,6 @@ objects:
         deploymentconfig: '${COMPONENT}-training-service'
       sessionAffinity: None
       type: ClusterIP
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      name: '${COMPONENT}-prediction-service'
-    spec:
-      lookupPolicy:
-        local: false
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      name: '${COMPONENT}-training-service'
-    spec:
-      lookupPolicy:
-        local: false
-  - apiVersion: v1
-    kind: BuildConfig
-    metadata:
-      name: ${COMPONENT}-prediction-service
-    spec:
-      completionDeadlineSeconds: "${{COMPLETION_DEADLINE_SECONDS}}"
-      failedBuildsHistoryLimit: 5
-      nodeSelector: null
-      output:
-        to:
-          kind: ImageStreamTag
-          name: ${COMPONENT}-prediction-service:${TAGVERSION}
-      postCommit: {}
-      resources: {}
-      runPolicy: Serial
-      source:
-        type: Binary
-        binary: {}
-      strategy:
-        type: Docker
-        dockerStrategy: {}
-      successfulBuildsHistoryLimit: 5
-  - apiVersion: v1
-    kind: BuildConfig
-    metadata:
-      name: ${COMPONENT}-training-service
-    spec:
-      completionDeadlineSeconds: "${{COMPLETION_DEADLINE_SECONDS}}"
-      failedBuildsHistoryLimit: 5
-      nodeSelector: null
-      output:
-        to:
-          kind: ImageStreamTag
-          name: ${COMPONENT}-training-service:${TAGVERSION}
-      postCommit: {}
-      resources:
-        limits:
-          cpu: '1'
-          memory: 2Gi
-        requests:
-          cpu: 500m
-          memory: 1Gi
-      runPolicy: Serial
-      source:
-        type: Binary
-        binary: {}
-      strategy:
-        type: Docker
-        dockerStrategy: {}
-      successfulBuildsHistoryLimit: 5
   - apiVersion: v1
     kind: DeploymentConfig
     metadata:

--- a/ds-ml-service/testdata/steps.yml
+++ b/ds-ml-service/testdata/steps.yml
@@ -18,9 +18,6 @@ steps:
           tag: latest
         - name: "{{.ComponentID}}-prediction-service"
           tag: latest
-        buildConfigs:
-        - "{{.ComponentID}}-training-service"
-        - "{{.ComponentID}}-prediction-service"
         imageStreams:
         - "{{.ComponentID}}-training-service"
         - "{{.ComponentID}}-prediction-service"

--- a/ds-rshiny/Jenkinsfile
+++ b/ds-rshiny/Jenkinsfile
@@ -28,17 +28,6 @@ odsQuickstarterPipeline(
       --nexus-username ${context.nexusUsername} \
       --nexus-password ${context.nexusPassword} \
       --non-interactive"""
-
-    for (def env : ['dev', 'test']) {
-      sh """oc patch bc ${context.componentId} --type=json --patch '
-        [{"op":
-          "replace", "path": "/spec/resources",
-          "value": {
-            "limits":{"cpu":"1","memory":"2Gi"},
-            "requests":{"cpu":"500m","memory":"1Gi"}
-          }
-        }]' -n ${context.projectId}-${env}"""
-    }
   }
 
   odsQuickstarterStageRenderJenkinsfile(context)

--- a/ds-rshiny/testdata/steps.yml
+++ b/ds-rshiny/testdata/steps.yml
@@ -12,8 +12,6 @@ steps:
         imageTags:
         - name: "{{.ComponentID}}"
           tag: latest
-        buildConfigs:
-        - "{{.ComponentID}}"
         imageStreams:
         - "{{.ComponentID}}"
         deploymentConfigs:

--- a/fe-angular/testdata/steps.yml
+++ b/fe-angular/testdata/steps.yml
@@ -17,8 +17,6 @@ steps:
         imageTags:
         - name: "{{.ComponentID}}"
           tag: latest
-        buildConfigs:
-        - "{{.ComponentID}}"
         imageStreams:
         - "{{.ComponentID}}"
         deploymentConfigs:

--- a/fe-ionic/testdata/steps.yml
+++ b/fe-ionic/testdata/steps.yml
@@ -17,8 +17,6 @@ steps:
         imageTags:
         - name: "{{.ComponentID}}"
           tag: latest
-        buildConfigs:
-        - "{{.ComponentID}}"
         imageStreams:
         - "{{.ComponentID}}"
         deploymentConfigs:

--- a/ods-document-gen-svc/testdata/steps.yml
+++ b/ods-document-gen-svc/testdata/steps.yml
@@ -19,7 +19,5 @@ steps:
         imageTags:
         - name: "{{.ComponentID}}"
           tag: "{{.SanitizedOdsGitRef}}"
-        buildConfigs:
-        - "{{.ComponentID}}"
         imageStreams:
         - "{{.ComponentID}}"

--- a/ods-provisioning-app/testdata/steps.yml
+++ b/ods-provisioning-app/testdata/steps.yml
@@ -19,7 +19,5 @@ steps:
         imageTags:
         - name: "{{.ComponentID}}"
           tag: "{{.SanitizedOdsGitRef}}"
-        buildConfigs:
-        - "{{.ComponentID}}"
         imageStreams:
         - "{{.ComponentID}}"


### PR DESCRIPTION
They are not required anymore in *-dev and *-test since https://github.com/opendevstack/ods-jenkins-shared-library/pull/517.

Consequently we remove the `BuildConfig` resources from the test steps. The `ImageStream` is still tested, as it should be automatically created in *-dev and *-test during the pipeline run.
