### PR TITLE
ds-ml-service: set stable scipy version required for scikit-learn

### DIFF
--- a/ds-ml-service/files/docker/Dockerfile
+++ b/ds-ml-service/files/docker/Dockerfile
@@ -41,6 +41,8 @@ RUN if [[ ! -z ${nexusHostWithBasicAuth} ]]; \
     else pip install --upgrade pip && pip install -r requirements.txt; \
     fi
 
+RUN pip check
+
 # Copying all the code
 COPY dist /app
 

--- a/ds-ml-service/files/src/requirements.txt
+++ b/ds-ml-service/files/src/requirements.txt
@@ -2,6 +2,7 @@ flask==1.1.2
 requests==2.24.0
 flask-executor==0.9.3
 pandas==1.0.5
+scipy==1.5.3
 scikit-learn==0.23.1
 numpy==1.19.1
 fabric==2.5.0


### PR DESCRIPTION
Fixes #531 

Once merged will cherry-pick to master too

Tasks: 
- [ not required ] Updated documentation in `docs/modules/...` directory
- [x] Ran tests in `<quickstarter>/testdata` directory
