### PR TITLE
Maven Agent- Select Java 11 version explicitly (3.x)

### DIFF
--- a/common/jenkins-agents/maven/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/maven/docker/Dockerfile.ubi8
@@ -22,6 +22,9 @@ ENV LANG=en_US.UTF-8 \
 # Install Maven
 RUN yum install -y --enablerepo centos-appstream java-11-openjdk-devel java-1.8.0-openjdk-devel maven && \
     yum clean all -y && \
+    exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1) && \
+    alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java && \
+    alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac && \
     mkdir -p $HOME/.m2 && \
     mkdir -p $GRADLE_USER_HOME && mkdir -p /tmp/gradle/wrapper && \
     java -version && \


### PR DESCRIPTION
Apply https://github.com/opendevstack/ods-quickstarters/pull/520 for 3.x as well. This only affects the UBI8 image.