### PR TITLE
fixes ods ami build branch 3.x failing due nodejs12 jenkins agent wrong dockerfile name

### DIFF
--- a/common/jenkins-agents/nodejs12/ocp-config/template.yaml
+++ b/common/jenkins-agents/nodejs12/ocp-config/template.yaml
@@ -18,6 +18,8 @@ parameters:
 - name: ODS_GIT_REF
   required: true
   value: production
+- name: JENKINS_AGENT_DOCKERFILE_PATH
+  value: Dockerfile.rhel7
 objects:
 - apiVersion: v1
   kind: ImageStream
@@ -64,6 +66,7 @@ objects:
             value: ${NEXUS_URL}
           - name: nexusAuth
             value: ${NEXUS_AUTH}
+        dockerfilePath: ${JENKINS_AGENT_DOCKERFILE_PATH}
         from:
           kind: ImageStreamTag
           name: jenkins-agent-base:${ODS_IMAGE_TAG}


### PR DESCRIPTION
ODS AMI build for branch 3.x is failing due to a wrong filename of dockerfile referenced in jenkins nodejs12 agent.
"error: open /tmp/build/inputs/common/jenkins-agents/nodejs12/docker/Dockerfile: no such file or directory"

This change fixes this by setting the correct filename.