### PR TITLE
Fix/ds rshiny cloudera repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- ds-rshiny cleanup cloudera dependency ([#540](https://github.com/opendevstack/ods-quickstarters/pull/540))
+
 ## [3.0] - 2020-08-11
 
 ### Added

--- a/ds-rshiny/files/docker/Dockerfile
+++ b/ds-rshiny/files/docker/Dockerfile
@@ -26,10 +26,6 @@ ENV LANG en_US.UTF-8
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
     echo 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu xenial/' > /etc/apt/sources.list.d/cran.list
 
-# Add Cloudera apt repo
-RUN apt-key adv --fetch-keys http://archive.cloudera.com/cdh5/ubuntu/xenial/amd64/cdh/archive.key && \
-    echo 'deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/xenial/amd64/cdh xenial-cdh5 contrib' > /etc/apt/sources.list.d/cloudera.list
-
 # Install dependencies
 RUN apt-get update && \
     apt-get install -yqq \
@@ -39,7 +35,6 @@ RUN apt-get update && \
         libxt-dev \
         pandoc \
         pandoc-citeproc \
-        hive-jdbc \
         r-base \
         r-base-dev \
         r-cran-rjava


### PR DESCRIPTION
Cleanup of the cloudera repo on the ds-rshiny quickstarter

Fixes #540

Tasks: 
- [not required] Updated documentation in `docs/modules/...` directory
- [x] Ran tests in `<quickstarter>/testdata` directory
