### PR TITLE
nodejs12 jenkins agent requires more memory resources when running on OpenShift4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - ds-rshiny cleanup cloudera dependency ([#540](https://github.com/opendevstack/ods-quickstarters/pull/540))
+- nodejs12 jenkins agent requires more memory on OpenShift4 ([#545](https://github.com/opendevstack/ods-quickstarters/pull/545))
 
 ## [3.0] - 2020-08-11
 

--- a/be-typescript-express/Jenkinsfile
+++ b/be-typescript-express/Jenkinsfile
@@ -16,6 +16,8 @@ library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
   imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs12:${agentImageTag}",
+  resourceRequestMemory: '1.5Gi',
+  resourceLimitMemory: '3Gi',
 ) { context ->
 
   stage("init Project") {

--- a/be-typescript-express/Jenkinsfile.template
+++ b/be-typescript-express/Jenkinsfile.template
@@ -4,6 +4,8 @@
 
 odsComponentPipeline(
   imageStreamTag: '@ods_namespace@/jenkins-agent-nodejs12:@agent_image_tag@',
+  resourceRequestMemory: '1.5Gi',
+  resourceLimitMemory: '3Gi',
   branchToEnvironmentMapping: [
     'master': 'dev',
   // 'release/': 'test'

--- a/e2e-cypress/Jenkinsfile
+++ b/e2e-cypress/Jenkinsfile
@@ -16,6 +16,8 @@ library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
   imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs12:${agentImageTag}",
+  resourceRequestMemory: '1.5Gi',
+  resourceLimitMemory: '3Gi',
 ) { context ->
 
   odsQuickstarterStageCopyFiles(context)

--- a/e2e-cypress/Jenkinsfile.template
+++ b/e2e-cypress/Jenkinsfile.template
@@ -4,6 +4,8 @@
 
 odsComponentPipeline(
   imageStreamTag: '@ods_namespace@/jenkins-agent-nodejs12:@agent_image_tag@',
+  resourceRequestMemory: '1.5Gi',
+  resourceLimitMemory: '3Gi',
   branchToEnvironmentMapping: [
     'master': 'dev',
   // 'release/': 'test'

--- a/fe-angular/Jenkinsfile
+++ b/fe-angular/Jenkinsfile
@@ -18,6 +18,8 @@ def angularCliVersion = "8.0.3"
 
 odsQuickstarterPipeline(
   imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs12:${agentImageTag}",
+  resourceRequestMemory: '1.5Gi',
+  resourceLimitMemory: '3Gi',
 ) { context ->
 
   stage("update angular cli") {

--- a/fe-angular/Jenkinsfile.template
+++ b/fe-angular/Jenkinsfile.template
@@ -4,6 +4,8 @@
 
 odsComponentPipeline(
   imageStreamTag: '@ods_namespace@/jenkins-agent-nodejs12:@agent_image_tag@',
+  resourceRequestMemory: '1.5Gi',
+  resourceLimitMemory: '3Gi',
   branchToEnvironmentMapping: [
     'master': 'dev',
   // 'release/': 'test'

--- a/fe-ionic/Jenkinsfile
+++ b/fe-ionic/Jenkinsfile
@@ -18,6 +18,8 @@ def ionicVersion = "5.4.16"
 
 odsQuickstarterPipeline(
   imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs12:${agentImageTag}",
+  resourceRequestMemory: '1.5Gi',
+  resourceLimitMemory: '3Gi',
 ) { context ->
 
   stage("update ionic cli") {

--- a/fe-ionic/Jenkinsfile.template
+++ b/fe-ionic/Jenkinsfile.template
@@ -4,6 +4,8 @@
 
 odsComponentPipeline(
   imageStreamTag: '@ods_namespace@/jenkins-agent-nodejs12:@agent_image_tag@',
+  resourceRequestMemory: '1.5Gi',
+  resourceLimitMemory: '3Gi',
   branchToEnvironmentMapping: [
     'master': 'dev',
   // 'release/': 'test'


### PR DESCRIPTION
Fixes #545 

Tasks: 
- [not required] Updated documentation in `docs/modules/...` directory
- [x] Ran tests in `<quickstarter>/testdata` directory
