### PR TITLE
e2e-spock-geb readme

### DIFF
--- a/e2e-spock-geb/README.md
+++ b/e2e-spock-geb/README.md
@@ -1,6 +1,6 @@
 # End-to-end tests with Spock, Geb and Unirest (e2e-spock-geb)
 
-Documentation is located in our [official documentation](https://www.opendevstack.org/ods-documentation/ods-project-quickstarters/latest/index.html)
+Documentation is located in our [official documentation](https://www.opendevstack.org/ods-documentation/opendevstack/3.x/quickstarters/e2e-spock-geb.html)
 
 Please update documentation in the [antora page directory](https://github.com/opendevstack/ods-project-quickstarters/tree/master/docs/modules/ROOT/pages)
 


### PR DESCRIPTION
I fixed the first link in the README for the e2e-spock-geb quickstarter, but then found the other 2 also have issues.

Tasks: 
- fixed link to opendevstack docs
- antora page directory link works, but there's no `.adoc` file for e2e-spock-geb.  Is that expected?
- automated tests link broken, and not sure where it should point to.
