### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,7 @@
 /e2e-spock-geb/ @metmajer
 /fe-angular/ @cschweikert
 /fe-ionic/ @rianet @bljubisic
+/inf-terraform-aws/ @frankjoas @metmajer @nichtraunzer @tbugfinder
 /ods-document-gen-svc/ @metmajer
 /ods-provisioning-app/ @clemensutschig @michaelsauter
 /release-manager/ @metmajer @michaelsauter


### PR DESCRIPTION
Upsate CODEOWNERS to match recent introduction of the AWS quickstarter (inf-terraform-aws)

