### PR TITLE
Feature/upgrade ionic cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Modified
 - Default linter for Ionic is now eslint as tslint is deprecated ([#573](https://github.com/opendevstack/ods-quickstarters/pull/575))
+- Upgraded Ionic CLI to v6.13.1 ([#577](https://github.com/opendevstack/ods-quickstarters/pull/577))
 
 ## Unreleased
 

--- a/docs/modules/quickstarters/pages/fe-ionic.adoc
+++ b/docs/modules/quickstarters/pages/fe-ionic.adoc
@@ -4,7 +4,7 @@ Ionic quickstarter project
 
 == Purpose of this quickstarter
 
-This quickstarter generates an Ionic 3 project, you can use it when you want to develop a cross platform mobile app (iOS, android and PWA) in one codebase using Web technologies like CSS, HTML and JavaScript/Typescript.
+This quickstarter generates an Ionic 6.13.1 project, you can use it when you want to develop a cross platform mobile app (iOS, android and PWA) in one codebase using Web technologies like CSS, HTML and JavaScript/Typescript.
 
 It contains the basic setup for https://www.docker.com/[Docker], https://jenkins.io/[Jenkins], https://www.sonarqube.org/[SonarQube] and https://www.openshift.com/[OpenShift], so you have your CI/CD process out of the box.
 
@@ -62,7 +62,7 @@ The files are generated using https://ionicframework.com/docs/cli/[Ionic CLI]. I
 == Frameworks used
 
 * https://ionicframework.com/docs/cli/[Ionic CLI]
-* https://ionicframework.com/docs/v3/[Ionic Framework]
+* https://ionicframework.com/docs/[Ionic Framework]
 * https://angular.io/[Angular]
 * http://www.typescriptlang.org/[Typescript]
 
@@ -73,7 +73,7 @@ As pre-requisite you'll need to have installed:
 * https://nodejs.org/en/download/[node]
 * npm which is bundled with the node installation
 * https://git-scm.com/downloads[git]
-* Ionic CLI globally in your local environment by running: `npm install -g ionic`
+* Ionic CLI globally in your local environment by running: `npm install -g @ionic/cli`
 
 Once you have you developer environment set up you can simply:
 

--- a/fe-ionic/Jenkinsfile
+++ b/fe-ionic/Jenkinsfile
@@ -14,7 +14,7 @@ node {
 
 library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
-def ionicVersion = "5.4.16"
+def ionicVersion = "6.13.1"
 def eslintVersion = "7.24.0"
 
 odsQuickstarterPipeline(

--- a/fe-ionic/Jenkinsfile.template
+++ b/fe-ionic/Jenkinsfile.template
@@ -22,7 +22,7 @@ odsComponentPipeline(
 def stageBuild(def context) {
   stage('Build') {
     withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}"]) {
-      sh 'npm i -g @ionic/cli@6.3.0'
+      sh 'npm i -g @ionic/cli@6.13.1'
       sh 'npm install'
       if ('master'.equals(context.gitBranch)) {
         sh 'ionic build --prod'

--- a/fe-ionic/files/README.md
+++ b/fe-ionic/files/README.md
@@ -1,5 +1,5 @@
 # Ionic Quickstarter
-Quickstarter created with Ionic CLI 6.3.0
+Quickstarter created with Ionic CLI 6.13.1
 
 ## Running unit tests
 All files with the ending `.spec.ts` in the src folder will be tested with karma

--- a/fe-ionic/files/metadata.yml
+++ b/fe-ionic/files/metadata.yml
@@ -1,6 +1,6 @@
 ---
 name: Ionic
-description: "Ionic Framework is the free, open source mobile UI toolkit for developing high-quality cross-platform apps for native iOS, Android, and the web—all from a single codebase. Technologies: Ionic 4.3"
+description: "Ionic Framework is the free, open source mobile UI toolkit for developing high-quality cross-platform apps for native iOS, Android, and the web—all from a single codebase. Technologies: Ionic 6.13.1"
 supplier: https://ionicframework.com
 version: 4.x
 type: ods


### PR DESCRIPTION
Upgrade the Ionic Quickstarter to use latest version (as of today) of ionic cli, which is v6.13.1

Closes #...
Fixes #...

Tasks: 
- [x] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
