### PR TITLE
Add recommended Kubernetes labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - requests access logging enabled for openshift oauth proxy component (used by ds-rshiny and ds-jupyter-lab) ([#590](https://github.com/opendevstack/ods-quickstarters/issues/590))
+- Add recommended Kubernetes labels ([512](https://github.com/opendevstack/ods-quickstarters/issues/512))
 
 ### Changed
 

--- a/be-gateway-nginx/files/metadata.yml
+++ b/be-gateway-nginx/files/metadata.yml
@@ -11,6 +11,9 @@ supplier: https://openresty.org
 # Version of the software deployed in this component.
 version: 1.19.3
 
+# Version of OpenDevStack
+odsVersion: 4.x
+
 # Type of component. One of ods, ods-service, ods-test or ods-infra.
 type: ods-service
 

--- a/be-gateway-nginx/files/metadata.yml
+++ b/be-gateway-nginx/files/metadata.yml
@@ -1,20 +1,8 @@
 ---
-# Human-friendly name of the software deployed in this component.
 name: nginx
-
-# Description of the component.
 description: "Enhanced nginx with Lua embeded. nginx [engine x] is an HTTP and reverse proxy server, a mail proxy server, and a generic TCP/UDP proxy server. Technologies: OpenResty/nginx 1.19.3.1"
-
-# URL of the home page for the software deployed in this component.
 supplier: https://openresty.org
-
-# Version of the software deployed in this component.
-version: 1.19.3
-
-# Version of OpenDevStack
-odsVersion: 4.x
-
-# Type of component. One of ods, ods-service, ods-test or ods-infra.
+version: 4.x
 type: ods-service
 
 # Id of the software deployed in this component. This can be based in the image name, maven artifactId...

--- a/be-gateway-nginx/files/metadata.yml
+++ b/be-gateway-nginx/files/metadata.yml
@@ -1,7 +1,36 @@
 ---
+# Human-friendly name of the software deployed in this component.
 name: nginx
+
+# Description of the component.
 description: "Enhanced nginx with Lua embeded. nginx [engine x] is an HTTP and reverse proxy server, a mail proxy server, and a generic TCP/UDP proxy server. Technologies: OpenResty/nginx 1.19.3.1"
+
+# URL of the home page for the software deployed in this component.
 supplier: https://openresty.org
-version: 4.x
+
+# Version of the software deployed in this component.
+version: 1.19.3
+
+# Type of component. One of ods, ods-service, ods-test or ods-infra.
 type: ods-service
-appName: nginx
+
+# Id of the software deployed in this component. This can be based in the image name, maven artifactId...
+# Default: component id.
+id: nginx
+
+# Role of this component in the project. One of frontend, backend, database, integration, cache, queue...
+# For nginx, most probably backend, frontend or integration.
+# Default: backend.
+# role: backend
+
+# Higher-level application or system this component is part of.
+# Could be the project name or some other application name. It is just a component grouping.
+# For example, if this could be a component of an on-line shop called Sock Shop:
+# partOf: sock-shop
+
+# Top-level system this application is part of.
+# systemName: acme-system
+
+# Project-wide version.
+# This version is typically shared by all components in the same project (or grouping, when specifying partOf).
+# projectVersion: 1.0

--- a/be-gateway-nginx/files/metadata.yml
+++ b/be-gateway-nginx/files/metadata.yml
@@ -4,3 +4,4 @@ description: "Enhanced nginx with Lua embeded. nginx [engine x] is an HTTP and r
 supplier: https://openresty.org
 version: 4.x
 type: ods-service
+appName: nginx


### PR DESCRIPTION
Adapted the metadata.yml of be-gateway-nginx quickstarter so that the appropriate labels will be automatically set to newly-provisioned components.

Closes #512

Tasks: 
- [X] Adapted metadata.yml of the be-gateway-nginx quickstarter
- [X] Added comments to document the usage of the different metadata entries
