### PR TITLE
Remove filter which disables all non centos 8 repos.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - ds-rshiny cleanup cloudera dependency ([#540](https://github.com/opendevstack/ods-quickstarters/pull/540))
 - Removed forcing eslint configuration as it is default ([#573](https://github.com/opendevstack/ods-quickstarters/pull/578))
 - Recover be-python-flask ([#583](https://github.com/opendevstack/ods-quickstarters/issues/583))
+- Fix UBI8 Build for Terraform Agent
 
 ### Removed
 

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -32,7 +32,6 @@ ENV HOME=/home/jenkins
 COPY python_requirements /tmp/requirements.txt
 
 RUN set -x \
-    && dnf repolist|grep -v -i centos|grep 8 |cut -f1 -d' '|xargs dnf config-manager --disable \
     && dnf -y install $INSTALL_PKGS
 
 RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" \


### PR DESCRIPTION
As requested by Felipe:
This fix removes the filter which disables all non centos 8 repos. 

The argument does not find any repos which matches the filter therefore it fails with exit 1.

Tasks: 
- [ ] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
