### PR TITLE
updating used base image for nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Removed forcing eslint configuration as it is default ([#573](https://github.com/opendevstack/ods-quickstarters/pull/578))
 - Default linter for Ionic is now eslint as tslint is deprecated ([#573](https://github.com/opendevstack/ods-quickstarters/pull/575))
 - Upgraded Ionic CLI to v6.13.1 ([#577](https://github.com/opendevstack/ods-quickstarters/pull/577))
+- Updating used base image for nginx to fix CVE ([#602](https://github.com/opendevstack/ods-quickstarters/pull/602))
 
 ### Fixed
 

--- a/fe-angular/files/docker/Dockerfile
+++ b/fe-angular/files/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.15.0-alpine
+FROM nginx:1.20.1-alpine
 
 RUN chmod -R 777 /var/log/nginx /var/cache/nginx /var/run \
      && chgrp -R 0 /etc/nginx \

--- a/fe-ionic/files/docker/Dockerfile
+++ b/fe-ionic/files/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.15.0-alpine
+FROM nginx:1.20.1-alpine
 
 RUN chmod -R 777 /var/log/nginx /var/cache/nginx /var/run \
      && chgrp -R 0 /etc/nginx \


### PR DESCRIPTION
nginx 1.15 was affected by [CVE-2021-23017](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23017) which is fixed / solved in nginx 1.20.1
This pull request updates the used base images to avoid that newly set up projects start with this vulnerability


