### PR TITLE
AWS Quickstarter: add AWS SAM/CDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - requests access logging enabled for openshift oauth proxy component (used by ds-rshiny and ds-jupyter-lab) ([#590](https://github.com/opendevstack/ods-quickstarters/issues/590))
 - e2e-cypress: Added support for login with Azure SSO + MSALv2 ([#601](https://github.com/opendevstack/ods-quickstarters/pull/601))
+- terraform jenkins agent: Added AWS SAM CLI and AWS CDK ([#608](https://github.com/opendevstack/ods-quickstarters/pull/608))
 
 ### Changed
 

--- a/common/jenkins-agents/terraform/docker/Dockerfile.rhel7
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.rhel7
@@ -20,7 +20,7 @@ ENV PACKER_VERSION 1.7.0
 ENV CONSUL_VERSION 1.9.4
 ENV TFENV_VERSION 2.2.0
 ENV BUNDLER_VERSION 2.2.14
-ENV NODE_VERSION 14.17.1
+ENV NODEJS_VERSION 14.17.1
 ENV GEM_HOME /opt/bundle
 ENV RBENV_ROOT /opt/rbenv
 ENV RBENV_SHELL bash
@@ -82,9 +82,9 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam
     && ./awssam/install && rm -f awssam.zip && rm -Rf ./awssam
 
 # Install aws cdk
-RUN wget -q "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
-    && xzcat node-v${NODE_VERSION}-linux-x64.tar.xz | tar xpf - -C /opt/ \
-    && mv /opt/node-v${NODE_VERSION}-linux-x64 /opt/node \
+RUN wget -q "https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-linux-x64.tar.xz" \
+    && xzcat node-v${NODEJS_VERSION}-linux-x64.tar.xz | tar xpf - -C /opt/ \
+    && mv /opt/node-v${NODEJS_VERSION}-linux-x64 /opt/node \
     && /opt/node/bin/npm install -g aws-cdk \
     && chown -R jenkins:root /opt/node && chmod +x /opt/node/bin/* \
     && node --version \

--- a/common/jenkins-agents/terraform/docker/Dockerfile.rhel7
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.rhel7
@@ -26,7 +26,7 @@ ENV RBENV_ROOT /opt/rbenv
 ENV RBENV_SHELL bash
 
 ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch readline readline-devel \
-    libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel"
+    libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel xz"
 ENV PATH=/opt/tfenv/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
 ENV HOME=/home/jenkins
 
@@ -86,7 +86,7 @@ RUN wget -q "https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-
     && xzcat node-v${NODEJS_VERSION}-linux-x64.tar.xz | tar xpf - -C /opt/ \
     && mv /opt/node-v${NODEJS_VERSION}-linux-x64 /opt/node \
     && /opt/node/bin/npm install -g aws-cdk \
-    && chown -R jenkins:root /opt/node && chmod +x /opt/node/bin/* \
+    && chown -R 1001:0 /opt/node && chmod +x /opt/node/bin/* \
     && node --version \
     && cdk --version
 

--- a/common/jenkins-agents/terraform/docker/Dockerfile.rhel7
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.rhel7
@@ -75,6 +75,11 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     && rm -f awscliv2.zip \
     && rm -Rf ./aws
 
+#Install awssamcli
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip" -o "awssam.zip" \
+    && unzip -qq -d awssam awssam.zip \
+    && ./awssam/install && rm -f awssam.zip && rm -Rf ./awssam
+
 # Install Terraform
 RUN wget -q -O /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
     && unzip /tmp/terraform.zip -d /usr/local/bin \

--- a/common/jenkins-agents/terraform/docker/Dockerfile.rhel7
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.rhel7
@@ -20,13 +20,14 @@ ENV PACKER_VERSION 1.7.0
 ENV CONSUL_VERSION 1.9.4
 ENV TFENV_VERSION 2.2.0
 ENV BUNDLER_VERSION 2.2.14
+ENV NODE_VERSION 14.17.1
 ENV GEM_HOME /opt/bundle
 ENV RBENV_ROOT /opt/rbenv
 ENV RBENV_SHELL bash
 
 ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch readline readline-devel \
     libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel"
-ENV PATH=/opt/tfenv/bin:/opt/rbenv/shims:/opt/rbenv/bin:$PATH
+ENV PATH=/opt/tfenv/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
 ENV HOME=/home/jenkins
 
 COPY python_requirements /tmp/requirements.txt
@@ -68,17 +69,26 @@ RUN pip config set global.cert /etc/ssl/certs/ca-bundle.crt \
 # Install python requirements
 RUN python3 -m pip install -r /tmp/requirements.txt
 
-#Install awscli2
+# Install awscli2
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip -qq awscliv2.zip \
     && ./aws/install \
     && rm -f awscliv2.zip \
     && rm -Rf ./aws
 
-#Install awssamcli
+# Install awssamcli
 RUN curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip" -o "awssam.zip" \
     && unzip -qq -d awssam awssam.zip \
     && ./awssam/install && rm -f awssam.zip && rm -Rf ./awssam
+
+# Install aws cdk
+RUN wget -q "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
+    && xzcat node-v${NODE_VERSION}-linux-x64.tar.xz | tar xpf - -C /opt/ \
+    && mv /opt/node-v${NODE_VERSION}-linux-x64 /opt/node \
+    && /opt/node/bin/npm install -g aws-cdk \
+    && chown -R jenkins:root /opt/node && chmod +x /opt/node/bin/* \
+    && node --version \
+    && cdk --version
 
 # Install Terraform
 RUN wget -q -O /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
@@ -86,7 +96,7 @@ RUN wget -q -O /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TE
     && rm -rf /tmp/terraform.zip \
     && terraform -h
 
-#Install tfenv
+# Install tfenv
 RUN umask 0002 && cd /opt && git clone --branch v${TFENV_VERSION} https://github.com/tfutils/tfenv.git \
     && TFENV_CURL_OUTPUT=0 /opt/tfenv/bin/tfenv install ${TERRAFORM_VERSION} \
     && /opt/tfenv/bin/tfenv use ${TERRAFORM_VERSION} \

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -20,13 +20,14 @@ ENV PACKER_VERSION 1.7.0
 ENV CONSUL_VERSION 1.9.4
 ENV TFENV_VERSION 2.2.0
 ENV BUNDLER_VERSION 2.2.14
+ENV NODE_VERSION 14.17.1
 ENV GEM_HOME /opt/bundle
 ENV RBENV_ROOT /opt/rbenv
 ENV RBENV_SHELL bash
 
 ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch readline readline-devel \
     libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel"
-ENV PATH=/opt/tfenv/bin:/opt/rbenv/shims:/opt/rbenv/bin:$PATH
+ENV PATH=/opt/tfenv/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
 ENV HOME=/home/jenkins
 
 COPY python_requirements /tmp/requirements.txt
@@ -50,17 +51,26 @@ RUN pip config set global.cert /etc/ssl/certs/ca-bundle.crt \
 # Install python requirements
 RUN python3 -m pip install -r /tmp/requirements.txt
 
-#Install awscli2
+# Install awscli2
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip -qq awscliv2.zip \
     && ./aws/install \
     && rm -f awscliv2.zip \
     && rm -Rf ./aws
 
-#Install awssamcli
+# Install awssamcli
 RUN curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip" -o "awssam.zip" \
     && unzip -qq -d awssam awssam.zip \
     && ./awssam/install && rm -f awssam.zip && rm -Rf ./awssam
+
+# Install aws cdk
+RUN wget -q "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
+    && xzcat node-v${NODE_VERSION}-linux-x64.tar.xz | tar xpf - -C /opt/ \
+    && mv /opt/node-v${NODE_VERSION}-linux-x64 /opt/node \
+    && /opt/node/bin/npm install -g aws-cdk \
+    && chown -R jenkins:root /opt/node && chmod +x /opt/node/bin/* \
+    && node --version \
+    && cdk --version
 
 # Install Terraform
 RUN wget -q -O /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
@@ -68,7 +78,7 @@ RUN wget -q -O /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TE
     && rm -rf /tmp/terraform.zip \
     && terraform -h
 
-#Install tfenv
+# Install tfenv
 RUN umask 0002 && cd /opt && git clone --branch v${TFENV_VERSION} https://github.com/tfutils/tfenv.git \
     && TFENV_CURL_OUTPUT=0 /opt/tfenv/bin/tfenv install ${TERRAFORM_VERSION} \
     && /opt/tfenv/bin/tfenv use ${TERRAFORM_VERSION} \
@@ -86,13 +96,13 @@ RUN wget -q -O /tmp/packer.zip "https://releases.hashicorp.com/packer/${PACKER_V
 RUN wget -q -O /usr/local/bin/terraform-docs https://github.com/segmentio/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64 \
     && chmod +x /usr/local/bin/terraform-docs
 
-#Install jq
+# Install jq
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
     && yum install -y jq parallel \
     && jq -Version \
     && yum clean all
 
-#Install consul-cli
+# Install consul-cli
 RUN wget -q "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip" \
     && unzip consul_${CONSUL_VERSION}_linux_amd64.zip -d /usr/local/bin \
     && rm -f consul_${CONSUL_VERSION}_linux_amd64.zip \

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -26,7 +26,7 @@ ENV RBENV_ROOT /opt/rbenv
 ENV RBENV_SHELL bash
 
 ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch readline readline-devel \
-    libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel"
+    libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel xz"
 ENV PATH=/opt/tfenv/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
 ENV HOME=/home/jenkins
 
@@ -68,7 +68,7 @@ RUN wget -q "https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-
     && xzcat node-v${NODEJS_VERSION}-linux-x64.tar.xz | tar xpf - -C /opt/ \
     && mv /opt/node-v${NODEJS_VERSION}-linux-x64 /opt/node \
     && /opt/node/bin/npm install -g aws-cdk \
-    && chown -R jenkins:root /opt/node && chmod +x /opt/node/bin/* \
+    && chown -R 1001:0 /opt/node && chmod +x /opt/node/bin/* \
     && node --version \
     && cdk --version
 

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -57,6 +57,11 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     && rm -f awscliv2.zip \
     && rm -Rf ./aws
 
+#Install awssamcli
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip" -o "awssam.zip" \
+    && unzip -qq -d awssam awssam.zip \
+    && ./awssam/install && rm -f awssam.zip && rm -Rf ./awssam
+
 # Install Terraform
 RUN wget -q -O /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
     && unzip /tmp/terraform.zip -d /usr/local/bin \

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -20,7 +20,7 @@ ENV PACKER_VERSION 1.7.0
 ENV CONSUL_VERSION 1.9.4
 ENV TFENV_VERSION 2.2.0
 ENV BUNDLER_VERSION 2.2.14
-ENV NODE_VERSION 14.17.1
+ENV NODEJS_VERSION 14.17.1
 ENV GEM_HOME /opt/bundle
 ENV RBENV_ROOT /opt/rbenv
 ENV RBENV_SHELL bash
@@ -64,9 +64,9 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam
     && ./awssam/install && rm -f awssam.zip && rm -Rf ./awssam
 
 # Install aws cdk
-RUN wget -q "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
-    && xzcat node-v${NODE_VERSION}-linux-x64.tar.xz | tar xpf - -C /opt/ \
-    && mv /opt/node-v${NODE_VERSION}-linux-x64 /opt/node \
+RUN wget -q "https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-linux-x64.tar.xz" \
+    && xzcat node-v${NODEJS_VERSION}-linux-x64.tar.xz | tar xpf - -C /opt/ \
+    && mv /opt/node-v${NODEJS_VERSION}-linux-x64 /opt/node \
     && /opt/node/bin/npm install -g aws-cdk \
     && chown -R jenkins:root /opt/node && chmod +x /opt/node/bin/* \
     && node --version \


### PR DESCRIPTION
Integrate AWS SAM CLI and AWS CDK into terraform agent so that developer frameworks can be integrated into the toolchain.

Tasks: 
- [ ] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
