### PR TITLE
switch ionic to nodejs12, backport jenkins-agent-nodejs12 from master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### Fixed
+- Fix Ionic quickstarter by adding Nodejs 12 as requirement for ODS 3.x ([#595](https://github.com/opendevstack/ods-quickstarters/issues/595))
+### Fixed
 - Fix Ionic quickstarter build after provisioning, proper npm install command ([#595](https://github.com/opendevstack/ods-quickstarters/issues/595))
 ### Fixed
 - Fix Ionic quickstarter build after provisioning ([#595](https://github.com/opendevstack/ods-quickstarters/issues/595))

--- a/common/jenkins-agents/nodejs12/docker/Dockerfile.rhel7
+++ b/common/jenkins-agents/nodejs12/docker/Dockerfile.rhel7
@@ -2,12 +2,12 @@ FROM opendevstackorg/ods-jenkins-agent-base-centos7:latest
 
 # Labels consumed by Red Hat build service
 LABEL com.redhat.component="jenkins-agent-nodejs-rhel7-docker" \
-      name="openshift3/jenkins-agent-nodejs-rhel7" \
-      version="3.6" \
-      architecture="x86_64" \
-      io.k8s.display-name="Jenkins agent Nodejs" \
-      io.k8s.description="The jenkins agent nodejs image has the nodejs tools on top of the jenkins agent base image." \
-      io.openshift.tags="openshift,jenkins,agent,nodejs"
+    name="openshift3/jenkins-agent-nodejs-rhel7" \
+    version="3.6" \
+    architecture="x86_64" \
+    io.k8s.display-name="Jenkins agent Nodejs" \
+    io.k8s.description="The jenkins agent nodejs image has the nodejs tools on top of the jenkins agent base image." \
+    io.openshift.tags="openshift,jenkins,agent,nodejs"
 
 ARG nexusUrl
 ARG nexusAuth
@@ -21,6 +21,38 @@ ENV NODEJS_VERSION=12 \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
+# install google-chrome (for angular)
+RUN yum-config-manager --enable rhel-7-server-extras-rpms && \
+    yum-config-manager --enable rhel-7-server-optional-rpms
+
+ADD https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm /root/google-chrome-stable_current_x86_64.rpm
+RUN yum -y install redhat-lsb libXScrnSaver
+RUN yum -y install /root/google-chrome-stable_current_x86_64.rpm && \
+    ln -s /usr/lib64/libOSMesa.so.8 /opt/google/chrome/libosmesa.so && \
+    yum clean all && \
+    dbus-uuidgen > /etc/machine-id
+
+
+# Install cypress dependencies
+# Please note: xorg-x11-server-Xvfb is not available on RHEL via yum anymore, so "RUN yum install -y xorg-x11-server-Xvfb" won't work.
+#   Therefore this Dockerfile uses the version from CentOS instead.
+ADD http://mirror.centos.org/centos/7/os/x86_64/Packages/xorg-x11-server-Xvfb-1.20.4-10.el7.x86_64.rpm /root/xorg-x11-server-Xvfb.x86_64.rpm
+RUN yum install -y /root/xorg-x11-server-Xvfb.x86_64.rpm && \
+    yum install -y gtk2-2.24* && \
+    yum install -y libXtst* && \
+    yum install -y libXScrnSaver* && \
+    yum install -y GConf2* && \
+    yum install -y alsa-lib* && \
+    yum install -y nss-devel libnotify-devel gnu-free-sans-fonts && \
+    yum clean all -y
+# libXScrnSaver* provides libXss
+# GConf2* provides libgconf-2
+# alsa-lib* provides libasound
+
+
+# Install NodeJS + Yarn + Angular CLI
+# installation details see: https://www.softwarecollections.org/en/
+# and the base image relies on scl_enable
 COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 
 # Install NodeJS

--- a/common/jenkins-agents/nodejs12/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/nodejs12/docker/Dockerfile.ubi8
@@ -28,8 +28,8 @@ RUN dbus-uuidgen > /etc/machine-id
 # https://docs.cypress.io/guides/getting-started/installing-cypress.html#System-requirements
 COPY yum.repos.d/google-chrome.repo /etc/yum.repos.d/google-chrome.repo
 RUN yum repolist \
-    && yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib \
-    && yum install -y google-chrome-stable \
+    && yum install -y --enablerepo centos-baseos,centos-appstream xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib \
+    && yum install -y --enablerepo centos-baseos,centos-appstream,google-chrome google-chrome-stable \
     && yum clean all -y
 
 # Install NodeJS (https://rpm.nodesource.com/setup_12.x does NOT work)

--- a/fe-ionic/Jenkinsfile.template
+++ b/fe-ionic/Jenkinsfile.template
@@ -3,7 +3,7 @@
 @Library('ods-jenkins-shared-library@@ods_git_ref@') _
 
 odsComponentPipeline(
-  imageStreamTag: '@ods_namespace@/jenkins-agent-nodejs10-angular:@ods_image_tag@',
+  imageStreamTag: '@ods_namespace@/jenkins-agent-nodejs12:@ods_image_tag@',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/': 'test'


### PR DESCRIPTION
Using Node 12 for running the Ionic quickstarter in ODS 3.x

Closes #595 
Fixes #595 
