### PR TITLE
fix dead sbt rpm bintray repo

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -150,20 +150,36 @@ jobs:
         run: |
           docker build --tag agent-terraform-test-ubi8 --file Dockerfile.ubi8 .
 
+  jenkins-agent-scala-rhel7:
+    name: Jenkins agent Scala (RHEL7)
+    runs-on: ubuntu-18.04
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v2.0.0
+      -
+        name: Build docker image
+        working-directory: common/jenkins-agents/scala/docker
+        run: |
+          docker build --tag agent-scala-test-rhel7 --file Dockerfile.rhel7 \
+             --build-arg nexusUrl=https://nexus.example.com \
+             --build-arg nexusUsername=developer \
+             --build-arg nexusPassword=s3cr3t \
+             .
 
-# jenkins-agent-scala:
-#   name: Jenkins agent Scala
-#   runs-on: ubuntu-18.04
-#   steps:
-#     -
-#       name: Checkout repository
-#       uses: actions/checkout@v2.0.0
-#     -
-#       name: Build docker image
-#       working-directory: common/jenkins-agents/scala/docker
-#       run: |
-#           docker build --tag agent-scala-test \
-#             --build-arg nexusUrl=https://nexus.example.com \
-#             --build-arg nexusUsername=developer \
-#             --build-arg nexusPassword=s3cr3t \
-#             .
+  jenkins-agent-scala-ubi8:
+    name: Jenkins agent Scala (UBI8)
+    runs-on: ubuntu-18.04
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v2.0.0
+      -
+        name: Build docker image
+        working-directory: common/jenkins-agents/scala/docker
+        run: |
+          docker build --tag agent-scala-test-rhel7 --file Dockerfile.ubi8 \
+             --build-arg nexusUrl=https://nexus.example.com \
+             --build-arg nexusUsername=developer \
+             --build-arg nexusPassword=s3cr3t \
+             .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fix UBI8 Build for Terraform Agent
 - ds-rshiny not able to deploy in OCP 4 ([#609](https://github.com/opendevstack/ods-quickstarters/issues/609))
 - fixed mixed line endings on multiple files ([#618](https://github.com/opendevstack/ods-quickstarters/issues/618))
+- fix dead sbt rpm bintray repo ([#622](https://github.com/opendevstack/ods-quickstarters/issues/622))
 
 ### Removed
 

--- a/common/jenkins-agents/scala/docker/Dockerfile.rhel7
+++ b/common/jenkins-agents/scala/docker/Dockerfile.rhel7
@@ -6,11 +6,23 @@ ARG nexusUrl
 ARG nexusUsername
 ARG nexusPassword
 
-ENV SBT_VERSION=1.3.13
-ENV SBT_CREDENTIALS="$HOME/.sbt/.credentials"
+# Install Java
+RUN yum install -y java-11-openjdk-devel && \
+    yum clean all -y && \
+    exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1) && \
+    alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java && \
+    alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac && \
+    java -version && \
+    javac -version
+ENV JAVA_HOME=/usr/lib/jvm/jre
 
-RUN curl -O -L http://dl.bintray.com/sbt/rpm/sbt-$SBT_VERSION.rpm && \
-    yum -y install sbt-$SBT_VERSION.rpm && \
+# Install sbt
+ENV SBT_VERSION=1.5.4
+ENV SBT_CREDENTIALS="$HOME/.sbt/.credentials"
+RUN rm -f /etc/yum.repos.d/bintray-rpm.repo && \
+    curl -L https://www.scala-sbt.org/sbt-rpm.repo > sbt-rpm.repo && \
+    mv sbt-rpm.repo /etc/yum.repos.d/ && \
+    yum -y install sbt-$SBT_VERSION && \
     yum clean all && \
     rm -rf /var/cache/yum
 
@@ -29,16 +41,10 @@ RUN cat $HOME/.sbt/repositories | sed -e "s|NEXUS_URL|$nexusUrl|g" > $HOME/.sbt/
     sed -i.bak -e "s|NEXUS_PASSWORD|$nexusPassword|g" $HOME/.sbt/.credentials && \
     rm $HOME/.sbt/.credentials.bak && \
     cd /tmp && \
-    /tmp/set_sbt_proxy.sh
+    /tmp/set_sbt_proxy.sh && \
+    if [ ! -f "/usr/bin/sbt" ]; then echo "sbt path /usr/bin/sbt could not be found"; exit 1 ; fi
 
-RUN sbt new scala/scala-seed.g8 --name="scala-test" -v && \
-    cd scala-test && \
-    sbt test && \
-    rm -rf /tmp/scala-test /tmp/target
 
-RUN	\
-    chgrp -R 0 $HOME && \
-    chmod -R 777 $HOME && \
-	chown -R 1001 $HOME
-
+RUN chgrp -R 0 $HOME && \
+    chmod -R g=u $HOME
 USER 1001

--- a/common/jenkins-agents/scala/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/scala/docker/Dockerfile.ubi8
@@ -6,12 +6,25 @@ ARG nexusUrl
 ARG nexusUsername
 ARG nexusPassword
 
-ENV SBT_CREDENTIALS="$HOME/.sbt/.credentials"
+# Install Java
+RUN yum install -y --enablerepo centos-appstream java-11-openjdk-devel && \
+    yum clean all -y && \
+    exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1) && \
+    alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java && \
+    alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac && \
+    java -version && \
+    javac -version
+ENV JAVA_HOME=/usr/lib/jvm/jre
 
-RUN curl -LfsSo /etc/yum.repos.d/bintray-sbt-rpm.repo https://bintray.com/sbt/rpm/rpm && \
-    yum install -y java-1.8.0-openjdk-devel.x86_64 sbt && \
+# Install sbt
+ENV SBT_VERSION=1.5.4
+ENV SBT_CREDENTIALS="$HOME/.sbt/.credentials"
+RUN rm -f /etc/yum.repos.d/bintray-rpm.repo && \
+    curl -L https://www.scala-sbt.org/sbt-rpm.repo > sbt-rpm.repo && \
+    mv sbt-rpm.repo /etc/yum.repos.d/ && \
+    yum -y install sbt-$SBT_VERSION && \
     yum clean all && \
-    rm -rf /var/cache/yum/*
+    rm -rf /var/cache/yum
 
 COPY sbtconfig/repositories $HOME/.sbt/repositories
 COPY sbtconfig/credentials.sbt $HOME/.sbt/1.0/plugins/credentials.sbt
@@ -28,17 +41,10 @@ RUN cat $HOME/.sbt/repositories | sed -e "s|NEXUS_URL|$nexusUrl|g" > $HOME/.sbt/
     sed -i.bak -e "s|NEXUS_PASSWORD|$nexusPassword|g" $HOME/.sbt/.credentials && \
     rm $HOME/.sbt/.credentials.bak && \
     cd /tmp && \
-    /tmp/set_sbt_proxy.sh
+    /tmp/set_sbt_proxy.sh && \
+    if [ ! -f "/usr/bin/sbt" ]; then echo "sbt path /usr/bin/sbt could not be found"; exit 1 ; fi
 
-RUN cd /tmp && \
-    sbt new scala/scala-seed.g8 --name="scala-test" -v && \
-    cd scala-test && \
-    sbt test && \
-    rm -rf /tmp/scala-test /tmp/target
 
-RUN	\
-    chgrp -R 0 $HOME && \
-    chmod -R 777 $HOME && \
-    chown -R 1001 $HOME
-
+RUN chgrp -R 0 $HOME && \
+    chmod -R g=u $HOME
 USER 1001


### PR DESCRIPTION
This PR fixes the issue that scala agents could not be build anymore due to the bintray sbt rpm repo not available anymore (https://jfrog.com/center-sunset/).

Furthermore it activates the build of the scala agents during execution of the CI via the github actions.
This build was disabled (thus we missed the problem with the dead rpm repo) due to the way the scala agent was build previously.
It included a test that verified, that sbt could be downloaded via nexus during the test image build.
Now a more lax test is executed, that allows us to verify that sbt was installed but excludes the nexus test.
No other agent for the build tools of ods verifies this by the way so I think it is the right tradeoff.

Closes #619 
Fixes #619 