### PR TITLE
fix nodejs12 chrome repo with http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - fix Smoke Test Region (AWS QS) ([#633](https://github.com/opendevstack/ods-quickstarters/issues/633)
 - fix openshift templates deprecation notice ([#639](https://github.com/opendevstack/ods-quickstarters/issues/639))
 - Bumps jupyterlab from 3.0.14 to 3.0.17 by @dependabot security finding ([#641](https://github.com/opendevstack/ods-quickstarters/pull/641))
+- fix nodejs 12 jenkins agent build failing ([#642](https://github.com/opendevstack/ods-quickstarters/issues/642)
 
 ### Removed
 

--- a/common/jenkins-agents/nodejs12/docker/yum.repos.d/google-chrome.repo
+++ b/common/jenkins-agents/nodejs12/docker/yum.repos.d/google-chrome.repo
@@ -1,6 +1,6 @@
 [google-chrome]
 name=google-chrome
-baseurl=http://dl.google.com/linux/chrome/rpm/stable/$basearch
+baseurl=https://dl.google.com/linux/chrome/rpm/stable/$basearch
 enabled=0
 gpgcheck=1
 gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub


### PR DESCRIPTION
The brother of https://github.com/opendevstack/ods-quickstarters/pull/643/ 

Fixes #642

Tasks: 
- [x] Updated documentation in `docs/modules/...` directory
- [x] Ran tests in `<quickstarter>/testdata` directory
