### PR TITLE
backport 3.x bugfix jenkins nodejs12 agent build failing due to incompatible chrome package with centos7 backport 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- jenkins nodejs12 agent build failing due to incompatible chrome package with centos 7 ([#656](https://github.com/opendevstack/ods-quickstarters/pull/656))
 - Fix Ionic quickstarter by adding Nodejs 12 as requirement for ODS 3.x ([#595](https://github.com/opendevstack/ods-quickstarters/issues/595))
 - Fix Ionic quickstarter build after provisioning, proper npm install command ([#595](https://github.com/opendevstack/ods-quickstarters/issues/595))
 - ds-rshiny cleanup cloudera dependency ([#540](https://github.com/opendevstack/ods-quickstarters/pull/540))

--- a/common/jenkins-agents/nodejs10-angular/docker/Dockerfile.rhel7
+++ b/common/jenkins-agents/nodejs10-angular/docker/Dockerfile.rhel7
@@ -20,20 +20,21 @@ ENV NODEJS_VERSION=10 \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH \
     BASH_ENV=/usr/local/bin/scl_enable \
     ENV=/usr/local/bin/scl_enable \
-    PROMPT_COMMAND=". /usr/local/bin/scl_enable"
+    PROMPT_COMMAND=". /usr/local/bin/scl_enable" \
+    CHROME_VERSION=94.0.4606.81
 
 # install google-chrome (for angular)
 RUN yum-config-manager --enable rhel-7-server-extras-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum makecache
 
-ADD https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm /root/google-chrome-stable_current_x86_64.rpm
+ADD https://dl.google.com/linux/chrome/rpm/stable/x86_64/google-chrome-stable-${CHROME_VERSION}-1.x86_64.rpm /root/google-chrome.rpm
 RUN yum -y install redhat-lsb libXScrnSaver
-RUN yum -y install /root/google-chrome-stable_current_x86_64.rpm && \
+RUN yum -y install /root/google-chrome.rpm && \
     ln -s /usr/lib64/libOSMesa.so.8 /opt/google/chrome/libosmesa.so && \
     yum clean all && \
-    dbus-uuidgen > /etc/machine-id
-
+    dbus-uuidgen > /etc/machine-id && \
+    rm /root/google-chrome.rpm
 
 # Install cypress dependencies
 # Please note: xorg-x11-server-Xvfb is not available on RHEL via yum anymore, so "RUN yum install -y xorg-x11-server-Xvfb" won't work.

--- a/common/jenkins-agents/nodejs12/docker/Dockerfile.rhel7
+++ b/common/jenkins-agents/nodejs12/docker/Dockerfile.rhel7
@@ -19,19 +19,20 @@ ENV NODEJS_VERSION=12 \
     ENV=/usr/local/bin/scl_enable \
     PROMPT_COMMAND=". /usr/local/bin/scl_enable" \
     LANG=en_US.UTF-8 \
-    LC_ALL=en_US.UTF-8
+    LC_ALL=en_US.UTF-8 \
+    CHROME_VERSION=94.0.4606.81
 
 # install google-chrome (for angular)
 RUN yum-config-manager --enable rhel-7-server-extras-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms
 
-ADD https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm /root/google-chrome-stable_current_x86_64.rpm
+ADD https://dl.google.com/linux/chrome/rpm/stable/x86_64/google-chrome-stable-${CHROME_VERSION}-1.x86_64.rpm /root/google-chrome.rpm
 RUN yum -y install redhat-lsb libXScrnSaver
-RUN yum -y install /root/google-chrome-stable_current_x86_64.rpm && \
+RUN yum -y install /root/google-chrome.rpm && \
     ln -s /usr/lib64/libOSMesa.so.8 /opt/google/chrome/libosmesa.so && \
     yum clean all && \
-    dbus-uuidgen > /etc/machine-id
-
+    dbus-uuidgen > /etc/machine-id && \
+    rm /root/google-chrome.rpm
 
 # Install cypress dependencies
 # Please note: xorg-x11-server-Xvfb is not available on RHEL via yum anymore, so "RUN yum install -y xorg-x11-server-Xvfb" won't work.


### PR DESCRIPTION
fixes #656 -> backport 3.x