### PR TITLE
Fix typescript express junit test location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - fix openshift templates deprecation notice ([#639](https://github.com/opendevstack/ods-quickstarters/issues/639))
 - Bumps jupyterlab from 3.0.14 to 3.0.17 by @dependabot security finding ([#641](https://github.com/opendevstack/ods-quickstarters/pull/641))
 - fix nodejs 12 jenkins agent build failing ([#642](https://github.com/opendevstack/ods-quickstarters/issues/642)
+- fix typescript-express junit test location ([#645](https://github.com/opendevstack/ods-quickstarters/issues/654))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 - fix openshift templates deprecation notice ([#639](https://github.com/opendevstack/ods-quickstarters/issues/639))
 - Bumps jupyterlab from 3.0.14 to 3.0.17 by @dependabot security finding ([#641](https://github.com/opendevstack/ods-quickstarters/pull/641))
 - fix nodejs 12 jenkins agent build failing ([#642](https://github.com/opendevstack/ods-quickstarters/issues/642)
-- fix typescript-express junit test location ([#645](https://github.com/opendevstack/ods-quickstarters/issues/654))
+- fix typescript-express junit test location ([#654](https://github.com/opendevstack/ods-quickstarters/issues/654))
 
 ### Removed
 

--- a/be-typescript-express/Jenkinsfile.template
+++ b/be-typescript-express/Jenkinsfile.template
@@ -31,22 +31,5 @@ def stageBuild(def context) {
 def stageUnitTest(def context) {
   stage('Unit Test') {
     sh 'npm run test'
-
-    if (false) {
-      junit 'artifacts/xunit.xml'
-      step([
-        $class: 'CoberturaPublisher',
-        autoUpdateHealth: false,
-        autoUpdateStability: false,
-        coberturaReportFile: 'artifacts/cobertura-coverage.xml',
-        failNoReports: false,
-        failUnhealthy: false,
-        failUnstable: false,
-        maxNumberOfBuilds: 0,
-        onlyStable: false,
-        sourceEncoding: 'UTF_8',
-        zoomCoverageChart: false
-      ])
-    }
   }
 }


### PR DESCRIPTION
Removed unnecessary part in the Jenkins.template which changes the location of the unit test report.

Closes #654 
Fixes #654 
