### PR TITLE
Add JVM parameters on docgen deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Modified
 
 - Added azure-cli to terraform agent ([#628](https://github.com/opendevstack/ods-quickstarters/issues/628))
+- Add JVM parameters on docgen deployment ([#669](https://github.com/opendevstack/ods-quickstarters/pull/669))
 
 ## [4.0] - 2021-05-11
 

--- a/release-manager/ocp-config/cd-docgen.yml
+++ b/release-manager/ocp-config/cd-docgen.yml
@@ -22,6 +22,12 @@ parameters:
   - name: MEMORY_REQUEST
     description: Minimum amount of memory requested for the container.
     value: 256Mi
+  - name: SERVICE_JVM_MEM_LIMIT
+    description: Maximum amount of memory available for the DocGen Service, render process memory needs to be handled by MEMORY_LIMIT parameter
+    value: 512m
+  - name: SERVICE_JVM_ARGS
+    description: JVM Tunning parameters for DocGen Service
+    value: "-XX:+UseCompressedOops -XX:+UseG1GC -XX:MaxGCPauseMillis=1000"    
   - name: DOCKER_REGISTRY
     description: Image registry
     required: true
@@ -94,6 +100,10 @@ objects:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               env:
+                - name: JAVA_MEM_XMX
+                  value: '${SERVICE_JVM_MEM_LIMIT}'
+                - name: JAVA_OPTS
+                  value: '${SERVICE_JVM_ARGS}'
                 - name: BITBUCKET_URL
                   value: '${BITBUCKET_URL}'
                 - name: BITBUCKET_USERNAME


### PR DESCRIPTION
Add JVM parameters on docgen deployment


**JAVA_MEM_XMX** and **JAVA_OPTS**

This PR is dependant of https://github.com/opendevstack/ods-document-generation-svc/pull/66