### PR TITLE
Add JVM parameters on docgen deployment 3x

### DIFF
--- a/release-manager/ocp-config/cd-docgen.yml
+++ b/release-manager/ocp-config/cd-docgen.yml
@@ -22,6 +22,12 @@ parameters:
   - name: MEMORY_REQUEST
     description: Minimum amount of memory requested for the container.
     value: 256Mi
+  - name: SERVICE_JVM_MEM_LIMIT
+    description: Maximum amount of memory available for the DocGen Service, render process memory needs to be handled by MEMORY_LIMIT parameter
+    value: 512m
+  - name: SERVICE_JVM_ARGS
+    description: JVM Tunning parameters for DocGen Service
+    value: "-XX:+UseCompressedOops -XX:+UseG1GC -XX:MaxGCPauseMillis=1000"
   - name: DOCKER_REGISTRY
     description: Image registry
     required: true
@@ -94,6 +100,10 @@ objects:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               env:
+                - name: JAVA_MEM_XMX
+                  value: '${SERVICE_JVM_MEM_LIMIT}'
+                - name: JAVA_OPTS
+                  value: '${SERVICE_JVM_ARGS}'
                 - name: BITBUCKET_URL
                   value: '${BITBUCKET_URL}'
                 - name: BITBUCKET_USERNAME


### PR DESCRIPTION
Add JVM parameters on docgen deployment


**JAVA_MEM_XMX** and **JAVA_OPTS**
