### PR TITLE
Add JVM parameters on docgen deployment 4x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+- Add JVM parameters on docgen deployment 4x ([#671](https://github.com/opendevstack/ods-quickstarters/pull/671))
 ## [4.0] - 2021-18-11
 
 ### Added

--- a/release-manager/ocp-config/cd-docgen.yml
+++ b/release-manager/ocp-config/cd-docgen.yml
@@ -21,6 +21,12 @@ parameters:
     value: 512Mi
   - name: MEMORY_REQUEST
     description: Minimum amount of memory requested for the container.
+  - name: SERVICE_JVM_MEM_LIMIT
+    description: Maximum amount of memory available for the DocGen Service, render process memory needs to be handled by MEMORY_LIMIT parameter
+    value: 512m
+  - name: SERVICE_JVM_ARGS
+    description: JVM Tunning parameters for DocGen Service
+    value: "-XX:+UseCompressedOops -XX:+UseG1GC -XX:MaxGCPauseMillis=1000"
     value: 256Mi
   - name: DOCKER_REGISTRY
     description: Image registry
@@ -94,6 +100,10 @@ objects:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               env:
+                - name: JAVA_MEM_XMX
+                  value: '${SERVICE_JVM_MEM_LIMIT}'
+                - name: JAVA_OPTS
+                  value: '${SERVICE_JVM_ARGS}'
                 - name: BITBUCKET_URL
                   value: '${BITBUCKET_URL}'
                 - name: BITBUCKET_USERNAME


### PR DESCRIPTION
Add JVM parameters on docgen deployment


**JAVA_MEM_XMX** and **JAVA_OPTS**
