### PR TITLE
Fix exitcode in Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added azure-cli to terraform agent ([#628](https://github.com/opendevstack/ods-quickstarters/issues/628))
 - Add JVM parameters on docgen deployment ([#669](https://github.com/opendevstack/ods-quickstarters/pull/669))
+- Fix error handling of Makefile ([#680](https://github.com/opendevstack/ods-quickstarters/issues/680))
 
 ## [4.0] - 2021-05-11
 

--- a/inf-terraform-aws/files/Makefile
+++ b/inf-terraform-aws/files/Makefile
@@ -4,7 +4,7 @@ DESCRIPTION              := The '$(NAME)' is a is a prototype for an ODS quickst
 PWD                      := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 GEMS_HOME                ?= $(PWD)/vendor/bundle
 INSTALL_REPORT_HOME      := ./reports/install
-SHELL                    := /usr/bin/env bash -o pipefail
+SHELL                    := /usr/bin/env bash
 .SHELLFLAGS              := -eu -o pipefail -c
 .DELETE_ON_ERROR:
 MAKEFLAGS                += --warn-undefined-variables

--- a/inf-terraform-aws/files/Makefile
+++ b/inf-terraform-aws/files/Makefile
@@ -4,7 +4,7 @@ DESCRIPTION              := The '$(NAME)' is a is a prototype for an ODS quickst
 PWD                      := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 GEMS_HOME                ?= $(PWD)/vendor/bundle
 INSTALL_REPORT_HOME      := ./reports/install
-SHELL                    := /usr/bin/env bash
+SHELL                    := /usr/bin/env bash -o pipefail
 
 TF_WORKSPACE             = default
 

--- a/inf-terraform-aws/files/Makefile
+++ b/inf-terraform-aws/files/Makefile
@@ -5,6 +5,10 @@ PWD                      := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIS
 GEMS_HOME                ?= $(PWD)/vendor/bundle
 INSTALL_REPORT_HOME      := ./reports/install
 SHELL                    := /usr/bin/env bash -o pipefail
+.SHELLFLAGS              := -eu -o pipefail -c
+.DELETE_ON_ERROR:
+MAKEFLAGS                += --warn-undefined-variables
+MAKEFLAGS                += --no-builtin-rules
 
 TF_WORKSPACE             = default
 
@@ -156,32 +160,4 @@ __check_defined = \
 	$(if $(value $1),, \
 		$(error Undefined $1$(if $2, ($2))$(if $(value @), \
 			required by target `$@')))
-
-# Execute tests in included blueprints.
-test_included_blueprints = \
-	function test_blueprint() { \
-		dir=$$(echo $$1 | jq -r '.Dir'); \
-		source=$$(echo $$1 | jq -r '.Source'); \
-		\
-		source=$$(basename $$source); \
-		if echo "$$source" | grep -q -e '\?ref='; then \
-			source=$$(echo $$source | sed 's/\(\.*\)?ref=.*/$1/'); \
-		fi; \
-		if echo "$$source" | grep -q -e '\.git$$'; then \
-			source=$$(echo $$source | sed 's/\(\.*\).git$$/$1/'); \
-		fi; \
-		\
-		if [ -f "$$dir/Makefile" ] && [ $$(grep -c "^test-report:" "$$dir/Makefile") == 1 ]; then \
-			echo "Running tests for module $$source in $$dir."; \
-			mkdir -p ./reports/install/data/blueprints/reports/test; \
-			GEMS_HOME=$(GEMS_HOME) make test-report -C $$dir || exit 1; \
-			cp "$$dir/reports/test/report.json" "./reports/install/data/blueprints/reports/test/$$source.json"; \
-		else \
-			echo "Module $$source in $$dir does not contain a valid Makefile. No tests executed."; \
-		fi \
-	}; \
-	\
-	if [ -f .terraform/modules/modules.json ]; then \
-		export -f test_blueprint; \
-		jq -c '.Modules | unique_by(.Source) | map(select(.Dir != ".")) | .[]' .terraform/modules/modules.json | parallel --halt soon,fail=1 --line-buffer --keep-order --quote test_blueprint "{}"; \
-	fi
+			


### PR DESCRIPTION
By updating shell options in Makefile error handling of the deployment stage works now.

Closes #680 

Tasks: 
- [ ] Updated documentation in `docs/modules/...` directory
- [x] Ran tests in an EDP in a Box.
