### PR TITLE
enforces minimal log4j2 version, disables log42 message lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Add JVM parameters on docgen deployment 4x ([#671](https://github.com/opendevstack/ods-quickstarters/pull/671))
 - Updates maven agent to support HTTPS proxy ([#689])(https://github.com/opendevstack/ods-quickstarters/issues/689))
+- Enforces use of secure Log4j version in SpringBoot Quickstarter ([#693](https://github.com/opendevstack/ods-quickstarters/issues/693))
 
 ## [4.0] - 2021-18-11
 
@@ -32,7 +33,6 @@
 - Updating used base image for nginx to fix CVE ([#602](https://github.com/opendevstack/ods-quickstarters/pull/602))
 - be-gateway-nginx switch from CentOS to Fedora ([#611](https://github.com/opendevstack/ods-quickstarters/issues/611))
 - Change rhel7 to centos7 base jenkins node, as the image is Centos (congruent with ods-core) ([#646](https://github.com/opendevstack/ods-quickstarters/pull/646))
-- Update external url dependencies ([#649](https://github.com/opendevstack/ods-quickstarters/pull/649))
 
 ### Fixed
 
@@ -53,8 +53,8 @@
 - fix openshift templates deprecation notice ([#639](https://github.com/opendevstack/ods-quickstarters/issues/639))
 - Bumps jupyterlab from 3.0.14 to 3.0.17 by @dependabot security finding ([#641](https://github.com/opendevstack/ods-quickstarters/pull/641))
 - fix nodejs 12 jenkins agent build failing ([#642](https://github.com/opendevstack/ods-quickstarters/issues/642)
-- fix typescript-express junit test report location ([#645](https://github.com/opendevstack/ods-quickstarters/issues/654))
-- fix java not in path for python quickstarter ([#645](https://github.com/opendevstack/ods-quickstarters/issues/685))
+- fix typescript-express junit test location ([#654](https://github.com/opendevstack/ods-quickstarters/issues/654))
+- fix java not in path for python quickstarter ([#685](https://github.com/opendevstack/ods-quickstarters/issues/685))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Updating used base image for nginx to fix CVE ([#602](https://github.com/opendevstack/ods-quickstarters/pull/602))
 - be-gateway-nginx switch from CentOS to Fedora ([#611](https://github.com/opendevstack/ods-quickstarters/issues/611))
 - Change rhel7 to centos7 base jenkins node, as the image is Centos (congruent with ods-core) ([#646](https://github.com/opendevstack/ods-quickstarters/pull/646))
+- Update external url dependencies ([#649](https://github.com/opendevstack/ods-quickstarters/pull/649))
 
 ### Fixed
 
@@ -53,8 +54,8 @@
 - fix openshift templates deprecation notice ([#639](https://github.com/opendevstack/ods-quickstarters/issues/639))
 - Bumps jupyterlab from 3.0.14 to 3.0.17 by @dependabot security finding ([#641](https://github.com/opendevstack/ods-quickstarters/pull/641))
 - fix nodejs 12 jenkins agent build failing ([#642](https://github.com/opendevstack/ods-quickstarters/issues/642)
-- fix typescript-express junit test location ([#654](https://github.com/opendevstack/ods-quickstarters/issues/654))
-- fix java not in path for python quickstarter ([#685](https://github.com/opendevstack/ods-quickstarters/issues/685))
+- fix typescript-express junit test report location ([#645](https://github.com/opendevstack/ods-quickstarters/issues/654))
+- fix java not in path for python quickstarter ([#645](https://github.com/opendevstack/ods-quickstarters/issues/685))
 
 ### Removed
 

--- a/be-java-springboot/Jenkinsfile
+++ b/be-java-springboot/Jenkinsfile
@@ -45,6 +45,9 @@ odsQuickstarterPipeline(
 
     echo "--- customise build.gradle ---"
 
+    // enforce minimal log4j2 version to avoid (CVE-2021-44228)
+	sh "sed -i -e '/ext {/{r ${context.sourceDir}/templates/gradle-minimal-log4j2-version.template'  -e 'd' -e '}' ${context.targetDir}/build.gradle"
+
     // add nexus credential settings
     sh "cat ${context.sourceDir}/templates/gradle-buildscript.template ${context.targetDir}/build.gradle >out && mv out ${context.targetDir}/build.gradle"
 

--- a/be-java-springboot/files/docker/Dockerfile
+++ b/be-java-springboot/files/docker/Dockerfile
@@ -1,5 +1,9 @@
 FROM adoptopenjdk/openjdk11:alpine-jre
 
+# Enforce runtime protection for log4j2 CVE-2021-44228 (affected version from 2.0 to 2.14.1) in the affected vesion is used.
+# This applies for version from 2.10 and not below.
+ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
+
 COPY app.jar app.jar
 
 EXPOSE 8080

--- a/be-java-springboot/templates/gradle-minimal-log4j2-version.template
+++ b/be-java-springboot/templates/gradle-minimal-log4j2-version.template
@@ -1,0 +1,3 @@
+ext['log4j2.version'] = '2.17.0'
+
+ext {


### PR DESCRIPTION
fixes #693 backport 4.x