### PR TITLE
jupyter lab with minimal initial env - use venvs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Updates maven agent to support HTTPS proxy ([#689])(https://github.com/opendevstack/ods-quickstarters/issues/689))
 - Enforces use of secure Log4j version in SpringBoot Quickstarter ([#693](https://github.com/opendevstack/ods-quickstarters/issues/693))
 - Use Java 17 (LTS) in maven jenkins-agent and spring boot qs ([#651](https://github.com/opendevstack/ods-quickstarters/pull/651))
+- Jupyter Lab: reduction to a minimal initial env ([#710](https://github.com/opendevstack/ods-quickstarters/issues/710))
 
 ### Fixed
 - inf-terraform-agent: fix pip update and epel installation
@@ -16,7 +17,7 @@
 ## [4.0] - 2021-05-11
 
 ### Added
- 
+
 - ds-rshiny cleanup cloudera dependency ([#540](https://github.com/opendevstack/ods-quickstarters/pull/540))
 - Add SaaS documentation quickstarter ([#556](https://github.com/opendevstack/ods-quickstarters/pull/556))
 - Documented the metadata file and its relationship with the labeling functionality ([#638](https://github.com/opendevstack/ods-quickstarters/pull/638))

--- a/ds-jupyter-lab/files/docker/requirements.txt
+++ b/ds-jupyter-lab/files/docker/requirements.txt
@@ -1,9 +1,3 @@
 jupyter==1.0.0
 ipywidgets==7.6.3
 jupyterlab==3.0.17
-numpy==1.20.2
-scipy==1.6.2
-scikit-learn==0.24.1
-pandas==1.2.4
-seaborn==0.11.1
-nltk==3.6.1


### PR DESCRIPTION
pick to 4.x from https://github.com/opendevstack/ods-quickstarters/pull/711

Tasks: 
- [x] Updated documentation in `docs/modules/...` directory
- [x] Ran tests in `<quickstarter>/testdata` directory
