### PR TITLE
terraform-agent integrate mozilla/sops and age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Use Java 17 (LTS) in maven jenkins-agent and spring boot qs ([#651](https://github.com/opendevstack/ods-quickstarters/pull/651))
 - ODS AMI build fails due to failing jacoco report generation in springboot quickstarter ([#700](https://github.com/opendevstack/ods-quickstarters/pull/700))
+- terraform agent sops/age added ([#730](https://github.com/opendevstack/ods-quickstarters/issues/730))
 
 ### Fixed
 

--- a/common/jenkins-agents/terraform/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.centos7
@@ -22,6 +22,8 @@ ENV CONSUL_VERSION 1.11.2
 ENV TFENV_VERSION 2.2.0
 ENV NODEJS_VERSION 16.13.2
 ENV BUNDLER_VERSION 2.2.23
+ENV SOPS_VERSION=3.7.1
+ENV AGE_VERSION=1.0.0
 ENV GEM_HOME /opt/bundle
 ENV RBENV_ROOT /opt/rbenv
 ENV RBENV_SHELL bash
@@ -140,6 +142,12 @@ RUN wget -q "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CO
     && rm -f consul_${CONSUL_VERSION}_linux_amd64.zip \
     && chmod +x /usr/local/bin/consul && /usr/local/bin/consul -version
     
+# Install mozilla/sops and AGE
+RUN yum install -y https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-${SOPS_VERSION}-1.x86_64.rpm \
+    && wget -q -O /tmp/age.tar.gz https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-amd64.tar.gz \
+    && tar xzf /tmp/age.tar.gz -C /usr/local/bin \
+    && rm -f /tmp/age.tar.gz
+
 RUN chown -R 1001:0 $HOME \
     && chmod -R g+rw $HOME \
     && mkdir -p $GEM_HOME \

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -21,6 +21,8 @@ ENV CONSUL_VERSION 1.11.2
 ENV TFENV_VERSION 2.2.0
 ENV NODEJS_VERSION 16.13.2
 ENV BUNDLER_VERSION 2.2.23
+ENV SOPS_VERSION=3.7.1
+ENV AGE_VERSION=1.0.0
 ENV GEM_HOME /opt/bundle
 ENV RBENV_ROOT /opt/rbenv
 ENV RBENV_SHELL bash
@@ -116,6 +118,12 @@ RUN wget -q "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CO
     && rm -f consul_${CONSUL_VERSION}_linux_amd64.zip \
     && chmod +x /usr/local/bin/consul && /usr/local/bin/consul -version
     
+# Install mozilla/sops and AGE
+RUN yum install -y https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-${SOPS_VERSION}-1.x86_64.rpm \
+    && wget -q -O /tmp/age.tar.gz https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-amd64.tar.gz \
+    && tar xzf /tmp/age.tar.gz -C /usr/local/bin \
+    && rm -f /tmp/age.tar.gz
+
 RUN chown -R 1001:0 $HOME \
     && chmod -R g+rw $HOME \
     && mkdir -p $GEM_HOME \


### PR DESCRIPTION
add sops&age tools to terraform agent supporting terraform-provider-sops

Closes #730 


Tasks: 
- [ ] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
