### PR TITLE
[ci skip] remove latest antora page alias from 4.x branch

### DIFF
--- a/docs/modules/quickstarters/pages/index.adoc
+++ b/docs/modules/quickstarters/pages/index.adoc
@@ -1,7 +1,6 @@
 :toc: macro
 
 = OpenDevStack Quickstarters
-:page-aliases: latest@ods-quickstarters:ROOT:index.adoc
 
 toc::[]
 


### PR DESCRIPTION
Fixes antora webpage build.
