### PR TITLE
python flask quickstarter upgrade to Flask 2 and general maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - terraform agent updated from Jenkins base image changes ([#724](https://github.com/opendevstack/ods-quickstarters/issues/724))
 - Bump antora page version in master (https://github.com/opendevstack/ods-documentation/issues/66)
 - Default acceptance test in Spock makes the pipeline runs forever ([#706](https://github.com/opendevstack/ods-quickstarters/issues/706))
+- Python Jenkinsfile use python3.8 ([#682](https://github.com/opendevstack/ods-quickstarters/issues/682))
 
 ### Modified
 
@@ -28,6 +29,7 @@
 - Enforce use of secure Log4j version in SpringBoot Quickstarter ([#693](https://github.com/opendevstack/ods-quickstarters/issues/693))
 - inf-terraform-aws: Update versions for ruby, terraform, kitchen-terraform, Gemfile ([#677](https://github.com/opendevstack/ods-quickstarters/issues/677))
 - jupyter lab: reduction to a minimal initial env ([#710](https://github.com/opendevstack/ods-quickstarters/issues/710))
+- upgrade python flask quickstarter to Flask 2 version and general dependencies upgrades ([#746](https://github.com/opendevstack/ods-quickstarters/issues/746))
 
 ## [4.0] - 2021-11-05
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 /be-gateway-nginx/ @gerardcl
 /be-golang-plain/ @michaelsauter @henrjk
 /be-java-springboot/ @stitakis @rdupont
-/be-python-flask/ @buegelbeatz @henrjk
+/be-python-flask/ @buegelbeatz @henrjk @gerardcl
 /be-scala-play/ @oalyman
 /be-typescript-express/ @sino92
 /docker-plain/ @michaelsauter

--- a/be-python-flask/Jenkinsfile.template
+++ b/be-python-flask/Jenkinsfile.template
@@ -29,7 +29,7 @@ def stageTestSuite(def context) {
 
   stage('Prepare Test Suite') {
     sh """
-      python -m venv testsuite
+      python3.8 -m venv testsuite
       . ./testsuite/bin/activate
       pip install -r tests_requirements.txt
       pip check
@@ -50,7 +50,7 @@ def stageTestSuite(def context) {
     def status = sh(
       script: """
         . ./testsuite/bin/activate
-        PYTHONPATH=src python -m pytest --junitxml=tests.xml -o junit_family=xunit2 --cov-report term-missing --cov-report xml --cov=src -o testpaths=tests
+        PYTHONPATH=src python3.8 -m pytest --junitxml=tests.xml -o junit_family=xunit2 --cov-report term-missing --cov-report xml --cov=src -o testpaths=tests
         mv tests.xml ${testLocation}
         mv coverage.xml ${coverageLocation}
         mv .coverage ${coverageLocation}

--- a/be-python-flask/README.md
+++ b/be-python-flask/README.md
@@ -1,8 +1,7 @@
-# Python Flask Quickstarter (be-python-flask) 
+# Python Flask Quickstarter (be-python-flask)
 
 Documentation is located in our [official documentation](https://www.opendevstack.org/ods-documentation/ods-quickstarters/latest/index.html)
 
 Please update documentation in the [antora page directory](https://github.com/opendevstack/ods-quickstarters/tree/master/docs/modules/ROOT/pages)
 
 Tested thru [automated tests](../tests/be-python-flask)
-

--- a/be-python-flask/files/metadata.yml
+++ b/be-python-flask/files/metadata.yml
@@ -1,6 +1,6 @@
 ---
 name: Flask
-description: "Flask is a micro web framework written in Python. Technologies: Flask 1.1.2, Python 3.8"
+description: "Flask is a micro web framework written in Python. Technologies: Flask 2.0.3, Python 3.8"
 supplier: https://www.palletsprojects.com/p/flask/
 version: 4.x
 type: ods

--- a/be-python-flask/files/requirements.txt
+++ b/be-python-flask/files/requirements.txt
@@ -1,2 +1,2 @@
 gunicorn==20.1.0
-flask==1.1.2
+flask==2.0.3

--- a/be-python-flask/files/tests_requirements.txt
+++ b/be-python-flask/files/tests_requirements.txt
@@ -1,6 +1,6 @@
 -r ./requirements.txt
 
-mypy==0.812
-flake8==3.9.1
-pytest==6.2.4
-pytest-cov==2.11.1
+mypy==0.931
+flake8==4.0.1
+pytest==7.0.1
+pytest-cov==3.0.0

--- a/docs/modules/quickstarters/pages/be-python-flask.adoc
+++ b/docs/modules/quickstarters/pages/be-python-flask.adoc
@@ -79,7 +79,7 @@ version: 1.0.1
 type: ods
 role: backend
 runtime: flask
-runtimeVersion: 1.1.2
+runtimeVersion: 2.0.3
 ```
 
 


### PR DESCRIPTION
Closes #746
Fixes #741
Fixes #682

Tasks: 
- [x] Updated documentation in `docs/modules/...` directory
- [x] Ran tests in `<quickstarter>/testdata` directory
