### PR TITLE
Fix .gitignore in in inf-terraform-aws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 - fix nodejs 12 jenkins agent build failing ([#642](https://github.com/opendevstack/ods-quickstarters/issues/642)
 - fix typescript-express junit test location ([#654](https://github.com/opendevstack/ods-quickstarters/issues/654))
 - fix java not in path for python quickstarter ([#685](https://github.com/opendevstack/ods-quickstarters/issues/685))
+- fix gitignore in inf-terraform ([#767](https://github.com/opendevstack/ods-quickstarters/issues/767))
 
 ### Removed
 

--- a/inf-terraform-aws/files/.gitignore
+++ b/inf-terraform-aws/files/.gitignore
@@ -14,5 +14,6 @@ vendor
 test/integration/*/files/*.json
 test/integration/*/files/*.yml
 reports/install/*
+!reports/install/.gitkeep
 Pipfile.lock
 .venv


### PR DESCRIPTION
When QS is deployed into an ODS project the reports/install directory is missing due to a conflict with .gitignore

Fixes #767   
