### PR TITLE
inf-terraform-aws: Fix link to docs

### DIFF
--- a/inf-terraform-aws/README.md
+++ b/inf-terraform-aws/README.md
@@ -2,5 +2,4 @@
 
 Documentation is located in our [official documentation](https://www.opendevstack.org/ods-documentation/ods-quickstarters/latest/index.html)
 
-Please update documentation in the [antora page directory](https://github.com/opendevstack/ods-quickstarters/tree/master/docs/modules/ROOT/pages)
-
+Please update documentation in the [antora page directory](https://github.com/opendevstack/ods-quickstarters/tree/master/docs/modules/quickstarters/pages)


### PR DESCRIPTION
Fix link to quickstarter docs




