### PR TITLE
inf-terraform-azure - fix Makefile pipe error handling

### DIFF
--- a/inf-terraform-azure/files/Makefile
+++ b/inf-terraform-azure/files/Makefile
@@ -5,6 +5,10 @@ PWD                      := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIS
 GEMS_HOME                ?= $(PWD)/vendor/bundle
 INSTALL_REPORT_HOME      := ./reports/install
 SHELL                    := /usr/bin/env bash
+.SHELLFLAGS              := -eu -o pipefail -c
+.DELETE_ON_ERROR:
+MAKEFLAGS                += --warn-undefined-variables
+MAKEFLAGS                += --no-builtin-rules
 
 TF_WORKSPACE             = default
 


### PR DESCRIPTION
sync with inf-terraform-aws Makefile add pipefail errors.


Tasks: 
- [ ] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
