### PR TITLE
add/enable Python 3.9, consistent use of  dnf in ubi8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - AWS Quickstarter enable devcontainer support for inf-terraform-aws ([#736](https://github.com/opendevstack/ods-quickstarters/issues/736))
 - Switch fe-angular, fe-ionic and be-typescript-express to Node.js 16 builder agent ([#763](https://github.com/opendevstack/ods-quickstarters/issues/763)
 - Update and improve e2e-cypress quickstarter ([#770](https://github.com/opendevstack/ods-quickstarters/issues/770))
+- inf-terraform-aws: consistent use of Python 3.9.x ([#793](https://github.com/opendevstack/ods-quickstarters/pull/793))
 
 ## [4.0] - 2021-11-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - AWS Quickstarter enable devcontainer support for inf-terraform-aws ([#736](https://github.com/opendevstack/ods-quickstarters/issues/736))
 - Switch fe-angular, fe-ionic and be-typescript-express to Node.js 16 builder agent ([#763](https://github.com/opendevstack/ods-quickstarters/issues/763)
 - Update and improve e2e-cypress quickstarter ([#770](https://github.com/opendevstack/ods-quickstarters/issues/770))
-- inf-terraform-aws: consistent use of Python 3.9.x ([#793](https://github.com/opendevstack/ods-quickstarters/pull/793))
+- inf-terraform-agent: consistent use of Python 3.9.x ([#793](https://github.com/opendevstack/ods-quickstarters/pull/793))
 
 ## [4.0] - 2021-11-05
 

--- a/common/jenkins-agents/terraform/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.centos7
@@ -15,7 +15,7 @@ LABEL com.redhat.component="jenkins-agent-terraform-rhel7-docker" \
 ENV TERRAFORM_VERSION 1.0.11
 ENV TERRAFORM_CONFIG_INSPECT_VERSION 0.2.0
 ENV TERRAFORM_DOCS_VERSION v0.16.0
-ENV PYTHON_VERSION 3.7.12
+ENV PYTHON_VERSION 3.9.11
 ENV RUBY_VERSION 2.7.5
 ENV PACKER_VERSION 1.7.10
 ENV CONSUL_VERSION 1.11.2
@@ -63,7 +63,7 @@ RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" \
 # Upgrade PIP
 RUN pip3 install --upgrade pip \
     && pip3 -V \
-    && pip3 install virtualenv pycodestyle
+    && pip3 install virtualenv pycodestyle wheel
 
 # Configure PIP SSL validation
 RUN pip config set global.cert /etc/ssl/certs/ca-bundle.crt \
@@ -73,16 +73,17 @@ RUN pip config set global.cert /etc/ssl/certs/ca-bundle.crt \
 RUN python3 -m pip install -r /tmp/requirements.txt
 
 # Install awscli2
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+RUN curl -sS "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip -qq awscliv2.zip \
     && ./aws/install \
+    && /usr/local/bin/aws --version \
     && rm -f awscliv2.zip \
     && rm -Rf ./aws
 
 # Install awssamcli
-RUN curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip" -o "awssam.zip" \
+RUN curl -L -sS "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip" -o "awssam.zip" \
     && unzip -qq -d awssam awssam.zip \
-    && ./awssam/install && rm -f awssam.zip && rm -Rf ./awssam
+    && ./awssam/install && /usr/local/bin/sam --version && rm -f awssam.zip && rm -Rf ./awssam
 
 # Install aws cdk
 RUN wget -q "https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-linux-x64.tar.xz" \

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -28,7 +28,8 @@ ENV RBENV_ROOT /opt/rbenv
 ENV RBENV_SHELL bash
 
 ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch readline readline-devel \
-    libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel xz"
+    libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel xz \
+    python39 python39-pip python39-setuptools"
 ENV PATH=/opt/tfenv/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
 ENV HOME=/home/jenkins
 
@@ -36,34 +37,33 @@ COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
 COPY python_requirements /tmp/requirements.txt
 
 RUN set -x \
+    && dnf clean all \
     && dnf -y install $INSTALL_PKGS
 
-RUN curl "https://bootstrap.pypa.io/pip/3.6/get-pip.py" -o "get-pip.py" \
-    && python3 get-pip.py
+# Upgrade pip
+RUN pip3.9 install --upgrade pip \
+    && pip3.9 -V \
+    && pip3.9 install virtualenv pycodestyle wheel
 
-# Upgrade PIP
-RUN pip3 install --upgrade pip \
-    && pip3 -V \
-    && pip3 install virtualenv pycodestyle
-
-# Configure PIP SSL validation
+# Configure pip SSL validation
 RUN pip config set global.cert /etc/ssl/certs/ca-bundle.crt \
     && pip config list
 
 # Install python requirements
-RUN python3 -m pip install -r /tmp/requirements.txt
+RUN python3.9 -m pip install -r /tmp/requirements.txt
 
 # Install awscli2
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+RUN curl -sS "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip -qq awscliv2.zip \
     && ./aws/install \
+    && /usr/local/bin/aws --version \
     && rm -f awscliv2.zip \
     && rm -Rf ./aws
 
 # Install awssamcli
-RUN curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip" -o "awssam.zip" \
+RUN curl -L -sS "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip" -o "awssam.zip" \
     && unzip -qq -d awssam awssam.zip \
-    && ./awssam/install && rm -f awssam.zip && rm -Rf ./awssam
+    && ./awssam/install && /usr/local/bin/sam --version && rm -f awssam.zip && rm -Rf ./awssam
 
 # Install aws cdk
 RUN wget -q "https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-linux-x64.tar.xz" \
@@ -106,11 +106,11 @@ RUN wget -q -O /tmp/terraform-docs.tar.gz https://github.com/terraform-docs/terr
     && chmod +x /usr/local/bin/terraform-docs
 
 # Install jq
-RUN yum -y install epel-release \
-    && yum install -y jq parallel \
+RUN dnf -y install epel-release \
+    && dnf install -y jq parallel \
     && jq -Version \
-    && yum clean all \
-    && yum-config-manager --disable epel
+    && dnf clean all \
+    && dnf config-manager --set-disabled epel
 
 # Install consul-cli
 RUN wget -q "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip" \
@@ -119,7 +119,7 @@ RUN wget -q "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CO
     && chmod +x /usr/local/bin/consul && /usr/local/bin/consul -version
     
 # Install mozilla/sops and AGE
-RUN yum install -y https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-${SOPS_VERSION}-1.x86_64.rpm \
+RUN dnf install -y https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-${SOPS_VERSION}-1.x86_64.rpm \
     && wget -q -O /tmp/age.tar.gz https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-amd64.tar.gz \
     && tar xzf /tmp/age.tar.gz -C /usr/local/bin \
     && rm -f /tmp/age.tar.gz


### PR DESCRIPTION
- sync centos7 and ubi8 Python installations to use Python 3.9.x.
- minor cleanup within Dockerfile.ubi8

Tasks: 
- [x] Built agents successfully
- [x] executed make init & pipenv shell successfully