### PR TITLE
fix quickstarters should specify the resources for the rollout process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Quickstarters should specify the resources for the rollout process ([#797](https://github.com/opendevstack/ods-quickstarters/issues/797))
 - Mavent agent updated from Jenkins base image changes ([#722](https://github.com/opendevstack/ods-quickstarters/issues/722))
 - NodeJS12 agent updated from Jenkins base image changes ([#720](https://github.com/opendevstack/ods-quickstarters/issues/720))
 - Scala agent updated from Jenkins base image changes ([#721](https://github.com/opendevstack/ods-quickstarters/issues/721))

--- a/common/ocp-config/component-environment/component-template.yml
+++ b/common/ocp-config/component-environment/component-template.yml
@@ -66,6 +66,9 @@ objects:
       strategy:
         activeDeadlineSeconds: 21600
         resources:
+        limits:
+          cpu: 200m
+          memory: 256Mi
         requests:
           cpu: 100m
           memory: 128Mi

--- a/common/ocp-config/component-environment/component-template.yml
+++ b/common/ocp-config/component-environment/component-template.yml
@@ -65,7 +65,10 @@ objects:
         deploymentconfig: "${COMPONENT}"
       strategy:
         activeDeadlineSeconds: 21600
-        resources: {}
+        resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
         rollingParams:
           intervalSeconds: 1
           maxSurge: 25%

--- a/common/ocp-config/component/template.yml
+++ b/common/ocp-config/component/template.yml
@@ -93,6 +93,9 @@ objects:
     strategy:
       activeDeadlineSeconds: 21600
       resources:
+        limits:
+          cpu: 200m
+          memory: 256Mi
         requests:
           cpu: 100m
           memory: 128Mi

--- a/common/ocp-config/component/template.yml
+++ b/common/ocp-config/component/template.yml
@@ -92,7 +92,10 @@ objects:
       deploymentconfig: "${COMPONENT}"
     strategy:
       activeDeadlineSeconds: 21600
-      resources: {}
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
       rollingParams:
         intervalSeconds: 1
         maxSurge: 25%

--- a/common/ocp-config/ds-component-environment/ds-component-oauthproxy.yml
+++ b/common/ocp-config/ds-component-environment/ds-component-oauthproxy.yml
@@ -105,7 +105,13 @@ objects:
         deploymentconfig: ${COMPONENT}-auth-proxy
       strategy:
         activeDeadlineSeconds: 21600
-        resources: {}
+        resources:
+        limits:
+          cpu: 200m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
         rollingParams:
           intervalSeconds: 1
           maxSurge: 25%

--- a/common/ocp-config/ds-component-environment/ds-component.yml
+++ b/common/ocp-config/ds-component-environment/ds-component.yml
@@ -76,7 +76,13 @@ objects:
         deploymentconfig: "${COMPONENT}"
       strategy:
         activeDeadlineSeconds: 21600
-        resources: {}
+        resources:
+        limits:
+          cpu: 200m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
         rollingParams:
           intervalSeconds: 1
           maxSurge: 25%


### PR DESCRIPTION
#797  @braisvq1996 

By default, pods consume unbounded node resources. However, if a project specifies default container limits, then pods consume resources up to those limits.

We can also limit resource use by specifying resource limits as part of the deployment strategy. However, if a quota has been defined for your project, one of the following two items is required:

A [limit range](https://docs.openshift.com/container-platform/3.3/admin_guide/limits.html#admin-guide-limits) defined in the project, where the defaults from the LimitRange object apply to pods created during the deployment process.

A resources section set with an explicit requests:

```
//...
strategy:
  //...
  resources:
    limits:
      requests: 
        cpu: 100m
        memory: 128Mi
  //...
```

Otherwise, deploy pod creation will fail, citing a failure to satisfy quota.

Tasks:

- [x] Updated ocp-config component templates


Fixes #797 