### PR TITLE
fix quickstarters should specify the resources for the rollout process #799

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Update fe-ionic to Ionic 6.19.0 ([#780](https://github.com/opendevstack/ods-quickstarters/issues/780))
 
 ### Fixed
+
+- Quickstarters should specify the resources for the rollout process ([#797](https://github.com/opendevstack/ods-quickstarters/issues/797))
 - inf-terraform-agent: fix pip update and epel installation
 - Mavent agent updated from Jenkins base image changes ([#722](https://github.com/opendevstack/ods-quickstarters/issues/722))
 - NodeJS12 agent updated from Jenkins base image changes ([#720](https://github.com/opendevstack/ods-quickstarters/issues/720))

--- a/common/ocp-config/component-environment/component-template.yml
+++ b/common/ocp-config/component-environment/component-template.yml
@@ -65,7 +65,13 @@ objects:
         deploymentconfig: "${COMPONENT}"
       strategy:
         activeDeadlineSeconds: 21600
-        resources: {}
+        resources:
+        limits:
+          cpu: 200m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
         rollingParams:
           intervalSeconds: 1
           maxSurge: 25%

--- a/common/ocp-config/component/template.yml
+++ b/common/ocp-config/component/template.yml
@@ -92,7 +92,13 @@ objects:
       deploymentconfig: "${COMPONENT}"
     strategy:
       activeDeadlineSeconds: 21600
-      resources: {}
+      resources:
+        limits:
+          cpu: 200m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
       rollingParams:
         intervalSeconds: 1
         maxSurge: 25%

--- a/common/ocp-config/ds-component-environment/ds-component-oauthproxy.yml
+++ b/common/ocp-config/ds-component-environment/ds-component-oauthproxy.yml
@@ -105,7 +105,13 @@ objects:
         deploymentconfig: ${COMPONENT}-auth-proxy
       strategy:
         activeDeadlineSeconds: 21600
-        resources: {}
+        resources:
+        limits:
+          cpu: 200m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
         rollingParams:
           intervalSeconds: 1
           maxSurge: 25%

--- a/common/ocp-config/ds-component-environment/ds-component.yml
+++ b/common/ocp-config/ds-component-environment/ds-component.yml
@@ -76,7 +76,13 @@ objects:
         deploymentconfig: "${COMPONENT}"
       strategy:
         activeDeadlineSeconds: 21600
-        resources: {}
+        resources:
+        limits:
+          cpu: 200m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
         rollingParams:
           intervalSeconds: 1
           maxSurge: 25%


### PR DESCRIPTION
#797 @braisvq1996

By default, pods consume unbounded node resources. However, if a project specifies default container limits, then pods consume resources up to those limits.

We can also limit resource use by specifying resource limits as part of the deployment strategy. However, if a quota has been defined for your project, one of the following two items is required:

A [limit range](https://docs.openshift.com/container-platform/3.3/admin_guide/limits.html#admin-guide-limits) defined in the project, where the defaults from the LimitRange object apply to pods created during the deployment process.

A resources section set with an explicit requests:

```
//...
strategy:
  //...
  resources:
    limits:
      cpu: 200m
      memory: 256Mi
    requests:
      cpu: 100m
      memory: 128Mi
  //...
```

Otherwise, deploy pod creation will fail, citing a failure to satisfy quota.

Tasks:

- [x] Updated ocp-config component templates

Fixes https://github.com/opendevstack/ods-quickstarters/issues/797