### PR TITLE
add comment in test fixture as module name and value of parameter name have to match

### DIFF
--- a/inf-terraform-aws/files/test/fixtures/default/main.tf
+++ b/inf-terraform-aws/files/test/fixtures/default/main.tf
@@ -8,6 +8,7 @@ locals {
 data "aws_region" "current" {}
 
 module "stack-aws-quickstarter-test" {
+  # module name and value of name parameter have to be equal
   source = "../../.."
 
   name             = local.name

--- a/inf-terraform-azure/files/test/fixtures/default/main.tf
+++ b/inf-terraform-azure/files/test/fixtures/default/main.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 module "stack-azure-quickstarter-test" {
+  # module name and value of name parameter have to be equal
   source = "../../.."
 
   is_test          = true


### PR DESCRIPTION
add comment in test fixture as module name and value of parameter name have to match.
This should improve the development experience as the hidden condition is shared.

Closes #802 
Fixes #802 

Tasks: 
- [ ] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
