### PR TITLE
4.x <- Full revision of Jenkins Pipelines, to make them work again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Switch fe-angular, fe-ionic and be-typescript-express to Node.js 16 builder agent ([#763](https://github.com/opendevstack/ods-quickstarters/issues/763)
 - Update and improve e2e-cypress quickstarter ([#770](https://github.com/opendevstack/ods-quickstarters/issues/770))
 - Update fe-ionic to Ionic 6.19.0 ([#780](https://github.com/opendevstack/ods-quickstarters/issues/780))
+- Upgrade atlassian stack (Implements [#1138](https://github.com/opendevstack/ods-core/issues/1138))
 
 ### Fixed
 
@@ -35,7 +36,9 @@
 - ODS AMI build failing due an E2E test error of ionic quickstarter ([#742](https://github.com/opendevstack/ods-quickstarters/issues/742))
 - ODS AMI build failing due an missing list of supported browsers in ionic quickstarter ([#756](https://github.com/opendevstack/ods-quickstarters/issues/756))
 - inf-terraform-aws: Fix error handling of Makefile ([#680](https://github.com/opendevstack/ods-quickstarters/issues/680))
-- Removes jcenter repositories and fixes jdk-17 problems. ([#807](https://github.com/opendevstack/ods-quickstarters/pull/807))
+- Remove jcenter repositories from quickstarters (Fixes [#804](https://github.com/opendevstack/ods-quickstarters/issues/804))
+- Fix non-working jdk-17 usage (Fixes [#808](https://github.com/opendevstack/ods-quickstarters/issues/808))
+- Full revision of Jenkins Pipelines, to make them work again. Increased timeouts for building quickstarters and added the retrieval of the return status for building each quickstarter.
 
 ## [4.0] - 2021-11-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - ODS AMI build failing due an E2E test error of ionic quickstarter ([#742](https://github.com/opendevstack/ods-quickstarters/issues/742))
 - ODS AMI build failing due an missing list of supported browsers in ionic quickstarter ([#756](https://github.com/opendevstack/ods-quickstarters/issues/756))
 - inf-terraform-aws: Fix error handling of Makefile ([#680](https://github.com/opendevstack/ods-quickstarters/issues/680))
+- Removes jcenter repositories and jdk-17 usage ([#807](https://github.com/opendevstack/ods-quickstarters/pull/807))
 
 ## [4.0] - 2021-11-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - ODS AMI build failing due an E2E test error of ionic quickstarter ([#742](https://github.com/opendevstack/ods-quickstarters/issues/742))
 - ODS AMI build failing due an missing list of supported browsers in ionic quickstarter ([#756](https://github.com/opendevstack/ods-quickstarters/issues/756))
 - inf-terraform-aws: Fix error handling of Makefile ([#680](https://github.com/opendevstack/ods-quickstarters/issues/680))
-- Removes jcenter repositories and jdk-17 usage ([#807](https://github.com/opendevstack/ods-quickstarters/pull/807))
+- Removes jcenter repositories and fixes jdk-17 problems. ([#807](https://github.com/opendevstack/ods-quickstarters/pull/807))
 
 ## [4.0] - 2021-11-05
 

--- a/be-java-springboot/Jenkinsfile
+++ b/be-java-springboot/Jenkinsfile
@@ -29,7 +29,7 @@ odsQuickstarterPipeline(
             -d dependencies='web,data-rest,restdocs,data-jpa,h2,security,devtools' \
             -d bootVersion=${springBootVersion} \
             -d packaging=jar \
-            -d javaVersion=11 \
+            -d javaVersion=17 \
             -d groupId=${context.projectId} \
             -d artifactId=${context.componentId} \
             -d name=${context.componentId} \

--- a/be-java-springboot/Jenkinsfile
+++ b/be-java-springboot/Jenkinsfile
@@ -29,7 +29,7 @@ odsQuickstarterPipeline(
             -d dependencies='web,data-rest,restdocs,data-jpa,h2,security,devtools' \
             -d bootVersion=${springBootVersion} \
             -d packaging=jar \
-            -d javaVersion=17 \
+            -d javaVersion=11 \
             -d groupId=${context.projectId} \
             -d artifactId=${context.componentId} \
             -d name=${context.componentId} \

--- a/be-java-springboot/Jenkinsfile.template
+++ b/be-java-springboot/Jenkinsfile.template
@@ -26,7 +26,7 @@ def stageBuild(def context) {
   }
   stage('Build and Unit Test') {
     withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}", "JAVA_OPTS=${javaOpts}","GRADLE_TEST_OPTS=${gradleTestOpts}","ENVIRONMENT=${springBootEnv}"]) {
-      def status = sh(script: "$HOME/use-j17.sh && ./gradlew clean build --stacktrace --no-daemon && $HOME/use-j11.sh", returnStatus: true)
+      def status = sh(script: "use-j17.sh && ./gradlew clean build --stacktrace --no-daemon && use-j11.sh", returnStatus: true)
       if (status != 0) {
         error "Build failed!"
       }

--- a/be-java-springboot/Jenkinsfile.template
+++ b/be-java-springboot/Jenkinsfile.template
@@ -26,7 +26,7 @@ def stageBuild(def context) {
   }
   stage('Build and Unit Test') {
     withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}", "JAVA_OPTS=${javaOpts}","GRADLE_TEST_OPTS=${gradleTestOpts}","ENVIRONMENT=${springBootEnv}"]) {
-      def status = sh(script: "$HOME/use-j17.sh && ./gradlew clean build --stacktrace --no-daemon && $HOME/use-j11.sh", returnStatus: true)
+      def status = sh(script: "./gradlew clean build --stacktrace --no-daemon", returnStatus: true)
       if (status != 0) {
         error "Build failed!"
       }

--- a/be-java-springboot/Jenkinsfile.template
+++ b/be-java-springboot/Jenkinsfile.template
@@ -26,7 +26,7 @@ def stageBuild(def context) {
   }
   stage('Build and Unit Test') {
     withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}", "JAVA_OPTS=${javaOpts}","GRADLE_TEST_OPTS=${gradleTestOpts}","ENVIRONMENT=${springBootEnv}"]) {
-      def status = sh(script: "./gradlew clean build --stacktrace --no-daemon", returnStatus: true)
+      def status = sh(script: "$HOME/use-j17.sh && ./gradlew clean build --stacktrace --no-daemon && $HOME/use-j11.sh", returnStatus: true)
       if (status != 0) {
         error "Build failed!"
       }

--- a/be-java-springboot/Jenkinsfile.template
+++ b/be-java-springboot/Jenkinsfile.template
@@ -26,7 +26,7 @@ def stageBuild(def context) {
   }
   stage('Build and Unit Test') {
     withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}", "JAVA_OPTS=${javaOpts}","GRADLE_TEST_OPTS=${gradleTestOpts}","ENVIRONMENT=${springBootEnv}"]) {
-      def status = sh(script: "use-j17.sh && ./gradlew clean build --stacktrace --no-daemon && use-j11.sh", returnStatus: true)
+      def status = sh(script: "source use-j17.sh && ./gradlew clean build --stacktrace --no-daemon && source use-j11.sh", returnStatus: true)
       if (status != 0) {
         error "Build failed!"
       }

--- a/be-java-springboot/templates/gradle-repositories.template
+++ b/be-java-springboot/templates/gradle-repositories.template
@@ -8,10 +8,8 @@
                 url repoUrl
             }
         }
-        nexusMaven("${nexus_url}/repository/jcenter/")
         nexusMaven("${nexus_url}/repository/maven-public/")
         nexusMaven("${nexus_url}/repository/atlassian_public/")
     } else {
         mavenCentral()
-        jcenter()
     }

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -32,7 +32,7 @@ RUN cat /etc/yum.repos.d/* && \
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
  RUN yum install -y epel-release && yum repolist && yum install -y java-17-openjdk-devel java-17-openjdk-jmods java-11-openjdk-devel java-11-openjdk-jmods && \
-    sh -c "yum list installed | grep -i '\(java\|jdk\)'" \
+    sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \
     yum clean all -y && rm -rf /var/cache/yum && \
     chmod ug+x /home/jenkins/use-j17.sh && \
     chmod ug+x /home/jenkins/use-j11.sh && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -26,9 +26,13 @@ ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryM
 # Copy use java scripts.
 COPY use-j*.sh /home/jenkins/
 
+RUN cat /etc/yum.repos.d/* && \
+    sed -i 's@http://cbs.centos.org/@https://cbs.centos.org/@g' /etc/yum.repos.d/*
+
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
  RUN yum install -y epel-release && yum repolist && yum install -y java-17-openjdk-devel java-17-openjdk-jmods java-11-openjdk-devel java-11-openjdk-jmods && \
+    sh -c "yum list installed | grep -i '\(java\|jdk\)'" \
     yum clean all -y && rm -rf /var/cache/yum && \
     chmod ug+x /home/jenkins/use-j17.sh && \
     chmod ug+x /home/jenkins/use-j11.sh && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -36,7 +36,6 @@ RUN cat /etc/yum.repos.d/* && \
     yum clean all -y && rm -rf /var/cache/yum && \
     chmod ug+x /home/jenkins/use-j17.sh && \
     chmod ug+x /home/jenkins/use-j11.sh && \
-    /home/jenkins/use-j17.sh && \
     /home/jenkins/use-j11.sh && \
     echo $JAVA_HOME
 

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -32,7 +32,9 @@ RUN cat /etc/yum.repos.d/* && \
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
 RUN yum -y --skip-broken update && \
-    yum install -y epel-release && yum repolist && \
+    yum install -y epel-release && \
+    yum updateinfo -t -y && \
+    yum repolist -t -y && \
     yum install -y java-11-openjdk-devel java-11-openjdk-jmods && \
     sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \
     yum clean all -y && rm -rf /var/cache/yum && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -106,7 +106,9 @@ RUN chmod 777 /tmp/set_gradle_proxy.sh
 RUN mkdir -pv $GRADLE_USER_HOME && \
     /tmp/set_gradle_proxy.sh
 
-RUN /tmp/gradlew -version
+RUN /tmp/gradlew -version && \
+    sh -c "source use-j17.sh && /tmp/gradlew -version" && \
+    sh -c "source use-j11.sh && /tmp/gradlew -version"
 
 #set java proxy via JAVA_OPTS as src
 RUN bash -l -c 'echo export JAVA_OPTS="$(/tmp/set_java_proxy.sh && echo $JAVA_OPTS)" >> /etc/bash.bashrc'

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -33,7 +33,7 @@ RUN cat /etc/yum.repos.d/* && \
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
 RUN yum -y --skip-broken update && \
     yum install -y epel-release && yum repolist && \
-    yum install -y java-11-openjdk-devel && \
+    yum install -y java-11-openjdk-devel java-11-openjdk-jmods && \
     sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \
     yum clean all -y && rm -rf /var/cache/yum && \
     chmod ug+x /home/jenkins/use-j17.sh && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -37,9 +37,6 @@ RUN rm -fv /etc/yum.repos.d/CentOS-Media.repo /etc/yum.repos.d/origin-local-rele
     sed -i 's@http://cbs.centos.org/@https://cbs.centos.org/@g' /etc/yum.repos.d/* && \
     grep -ri '^\s*\(name\|enabled\)\s*=' /etc/yum.repos.d/*
 
-# Copy use java scripts.
-COPY use-j*.sh /home/jenkins/
-
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
 RUN yum -y --skip-broken update && \
@@ -49,14 +46,18 @@ RUN yum -y --skip-broken update && \
     yum updateinfo -t -y && \
     yum repolist -t -y && \
     sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \
-    yum clean all -y && rm -rf /var/cache/yum && \
-    chmod ug+x /home/jenkins/use-j17.sh && \
-    chmod ug+x /home/jenkins/use-j11.sh && \
-    echo "--- STARTS JDK 11/17 TESTS ---" && \
-    /home/jenkins/use-j17.sh && \
-    /home/jenkins/use-j11.sh && \
-    echo "--- ENDS JDK 11/17 TESTS ---"
+    yum clean all -y && rm -rf /var/cache/yum
 
+# Copy use java scripts.
+COPY use-j*.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/use-j*.sh && \
+    chmod ugo+s /usr/local/bin/use-j*.sh && \
+    sh -c 'chmod ugo+s $(which alternatives)' && \
+    ls -la /usr/local/bin/use-j*.sh && \
+    echo "--- STARTS JDK 11/17 TESTS ---" && \
+    use-j17.sh && \
+    use-j11.sh && \
+    echo "--- ENDS JDK 11/17 TESTS ---"
 
 # Install Maven
 ENV MAVEN_VERSION=3.5.4
@@ -71,21 +72,26 @@ RUN mkdir -p /usr/share/maven /usr/share/maven/ref && \
 ENV MAVEN_HOME=/usr/share/maven
 ENV MAVEN_CONFIG=$HOME/.m2
 
-# set java proxy var
-COPY set_maven_proxy.sh /tmp/set_maven_proxy.sh
-RUN chmod 777 /tmp/set_maven_proxy.sh
-
 ADD ./contrib/settings.xml $HOME/.m2/
-RUN mv $HOME/.m2/settings.xml $HOME/.m2/settings.xml.orig && \
- /tmp/set_maven_proxy.sh && \
- xpr=$(cat /tmp/mvn_proxy) && \
- xpr="${xpr//\//\\/}" && \
- xpr="${xpr//|/\\|}" && \
- cat $HOME/.m2/settings.xml.orig | sed -e "s|<proxies>|<proxies>$xpr|g" > $HOME/.m2/settings.xml && \
- sed -i "s/__NEXUS_USER/$nexusUsername/gi" $HOME/.m2/settings.xml && \
- sed -i "s/__NEXUS_PW/$nexusPassword/gi" $HOME/.m2/settings.xml && \
- sed -i "s|__NEXUS_URL|$nexusUrl|gi" $HOME/.m2/settings.xml && \
- cat $HOME/.m2/settings.xml
+
+COPY set_maven_proxy.sh /tmp/set_maven_proxy.sh
+COPY set_gradle_proxy.sh /tmp/set_gradle_proxy.sh
+
+RUN mkdir -p $HOME/.m2 && \
+    mkdir -p $GRADLE_USER_HOME && mkdir -p /tmp/gradle/wrapper && \
+    mvn -v && \
+    chmod +x /tmp/set_maven_proxy.sh && \
+    chmod +x /tmp/set_gradle_proxy.sh && \
+    mv $HOME/.m2/settings.xml $HOME/.m2/settings.xml.orig && \
+    /tmp/set_maven_proxy.sh && \
+    xpr=$(cat /tmp/mvn_proxy) && \
+    xpr="${xpr//\//\\/}" && \
+    xpr="${xpr//|/\\|}" && \
+    cat $HOME/.m2/settings.xml.orig | sed -e "s|<proxies>|<proxies>$xpr|g" > $HOME/.m2/settings.xml && \
+    sed -i "s/__NEXUS_USER/$nexusUsername/gi" $HOME/.m2/settings.xml && \
+    sed -i "s/__NEXUS_PW/$nexusPassword/gi" $HOME/.m2/settings.xml && \
+    sed -i "s|__NEXUS_URL|$nexusUrl|gi" $HOME/.m2/settings.xml && \
+    cat $HOME/.m2/settings.xml
 
 # install gradle ..
 ADD gradlew /tmp/gradlew
@@ -97,8 +103,8 @@ RUN ls /tmp/gradle/wrapper
 COPY set_gradle_proxy.sh /tmp/set_gradle_proxy.sh
 RUN chmod 777 /tmp/set_gradle_proxy.sh
 
-RUN mkdir $GRADLE_USER_HOME
-RUN /tmp/set_gradle_proxy.sh
+RUN mkdir -pv $GRADLE_USER_HOME && \
+    /tmp/set_gradle_proxy.sh
 
 RUN /tmp/gradlew -version
 
@@ -106,7 +112,6 @@ RUN /tmp/gradlew -version
 RUN bash -l -c 'echo export JAVA_OPTS="$(/tmp/set_java_proxy.sh && echo $JAVA_OPTS)" >> /etc/bash.bashrc'
 
 RUN chown -R 1001:0 $HOME && \
-    chown 1001:0 $HOME/use-j*.sh && \
     chmod -R g+rw $HOME && \
     chmod -c 666 /etc/pki/ca-trust/extracted/java/cacerts && \
     ls -la /etc/pki/ca-trust/extracted/java/cacerts

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -29,11 +29,13 @@ COPY use-j*.sh /home/jenkins/
 RUN cat /etc/yum.repos.d/* && \
     sed -i 's@http://cbs.centos.org/@https://cbs.centos.org/@g' /etc/yum.repos.d/*
 
-RUN yum --disablerepo=epel -y update ca-certificates
+# Needed b
+RUN
 
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
-RUN yum install -y epel-release && yum repolist && yum install -y java-17-openjdk-devel java-17-openjdk-jmods java-11-openjdk-devel java-11-openjdk-jmods && \
+RUN yum -y update && \
+    yum install -y epel-release && yum repolist && yum install -y java-17-openjdk-devel java-17-openjdk-jmods java-11-openjdk-devel java-11-openjdk-jmods && \
     sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \
     yum clean all -y && rm -rf /var/cache/yum && \
     chmod ug+x /home/jenkins/use-j17.sh && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -31,7 +31,7 @@ RUN cat /etc/yum.repos.d/* && \
 
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
-RUN yum -y --nobest --skip-broken update && \
+RUN yum -y --skip-broken update && \
     yum install -y epel-release && yum repolist && \
     yum install -y java-11-openjdk-devel java-11-openjdk-jmods && \
     sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -31,8 +31,9 @@ RUN cat /etc/yum.repos.d/* && \
 
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
-RUN yum -y update && \
-    yum install -y epel-release && yum repolist && yum install -y java-17-openjdk-devel java-17-openjdk-jmods java-11-openjdk-devel java-11-openjdk-jmods && \
+RUN yum -y --nobest --skip-broken update && \
+    yum install -y epel-release && yum repolist && \
+    yum install -y java-11-openjdk-devel java-11-openjdk-jmods && \
     sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \
     yum clean all -y && rm -rf /var/cache/yum && \
     chmod ug+x /home/jenkins/use-j17.sh && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -33,7 +33,7 @@ RUN cat /etc/yum.repos.d/* && \
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
 RUN yum -y --skip-broken update && \
     yum install -y epel-release && yum repolist && \
-    yum install -y java-11-openjdk-devel java-11-openjdk-jmods && \
+    yum install -y java-11-openjdk-devel && \
     sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \
     yum clean all -y && rm -rf /var/cache/yum && \
     chmod ug+x /home/jenkins/use-j17.sh && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -29,9 +29,11 @@ COPY use-j*.sh /home/jenkins/
 RUN cat /etc/yum.repos.d/* && \
     sed -i 's@http://cbs.centos.org/@https://cbs.centos.org/@g' /etc/yum.repos.d/*
 
+RUN yum --disablerepo=epel -y update ca-certificates
+
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
- RUN yum install -y epel-release && yum repolist && yum install -y java-17-openjdk-devel java-17-openjdk-jmods java-11-openjdk-devel java-11-openjdk-jmods && \
+RUN yum install -y epel-release && yum repolist && yum install -y java-17-openjdk-devel java-17-openjdk-jmods java-11-openjdk-devel java-11-openjdk-jmods && \
     sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \
     yum clean all -y && rm -rf /var/cache/yum && \
     chmod ug+x /home/jenkins/use-j17.sh && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -29,9 +29,6 @@ COPY use-j*.sh /home/jenkins/
 RUN cat /etc/yum.repos.d/* && \
     sed -i 's@http://cbs.centos.org/@https://cbs.centos.org/@g' /etc/yum.repos.d/*
 
-# Needed b
-RUN
-
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
 RUN yum -y update && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -30,12 +30,12 @@ ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryM
 
 COPY yum.repos.d/adoptium-temurin.repo /etc/yum.repos.d/
 RUN rm -fv /etc/yum.repos.d/CentOS-Media.repo /etc/yum.repos.d/origin-local-release.repo && \
-    grep -ri '^\s*\(name\|enabled\)\s*=' /etc/yum.repos.d/* && \
     sh -c "echo 'centos' > /etc/yum/vars/osname" && \
-    sed -i 's@^\s*enabled\s*=.*$@enabled = 1@g' /etc/yum.repos.d/*.repo && \
+    sed -i 's@^\s*enabled\s*=.*$@enabled = 1@g' /etc/yum.repos.d/CentOS-Sources.repo && \
     sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/CentOS-Vault.repo && \
     sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/adoptium-temurin.repo && \
-    sed -i 's@http://cbs.centos.org/@https://cbs.centos.org/@g' /etc/yum.repos.d/*
+    sed -i 's@http://cbs.centos.org/@https://cbs.centos.org/@g' /etc/yum.repos.d/* && \
+    grep -ri '^\s*\(name\|enabled\)\s*=' /etc/yum.repos.d/*
 
 # Copy use java scripts.
 COPY use-j*.sh /home/jenkins/

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -92,6 +92,8 @@ RUN bash -l -c 'echo export JAVA_OPTS="$(/tmp/set_java_proxy.sh && echo $JAVA_OP
 
 RUN chown -R 1001:0 $HOME && \
     chown 1001:0 $HOME/use-j*.sh && \
-    chmod -R g+rw $HOME
+    chmod -R g+rw $HOME && \
+    chmod -c 666 /etc/pki/ca-trust/extracted/java/cacerts && \
+    ls -la /etc/pki/ca-trust/extracted/java/cacerts
 USER 1001
 

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -23,25 +23,40 @@ ENV HOME=/home/jenkins \
 # Container support is now integrated in Java 11, the +UseCGroupMemoryLimitForHeap option has been pruned
 ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true"
 
+# Workaroud we use when running behind proxy
+# Basically we put the proxy certificate in certs folder
+# COPY certs/* /etc/pki/ca-trust/source/anchors/
+# RUN update-ca-trust force-enable && update-ca-trust extract
+
+COPY yum.repos.d/adoptium-temurin.repo /etc/yum.repos.d/
+RUN rm -fv /etc/yum.repos.d/CentOS-Media.repo /etc/yum.repos.d/origin-local-release.repo && \
+    grep -ri '^\s*\(name\|enabled\)\s*=' /etc/yum.repos.d/* && \
+    sh -c "echo 'centos' > /etc/yum/vars/osname" && \
+    sed -i 's@^\s*enabled\s*=.*$@enabled = 1@g' /etc/yum.repos.d/*.repo && \
+    sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/CentOS-Vault.repo && \
+    sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/adoptium-temurin.repo && \
+    sed -i 's@http://cbs.centos.org/@https://cbs.centos.org/@g' /etc/yum.repos.d/*
+
 # Copy use java scripts.
 COPY use-j*.sh /home/jenkins/
-
-RUN cat /etc/yum.repos.d/* && \
-    sed -i 's@http://cbs.centos.org/@https://cbs.centos.org/@g' /etc/yum.repos.d/*
 
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
 RUN yum -y --skip-broken update && \
     yum install -y epel-release && \
+    yum install -y java-11-openjdk-devel maven-3.5.4 && \
+    yum install -y --enablerepo Adoptium temurin-17-jdk && \
     yum updateinfo -t -y && \
     yum repolist -t -y && \
-    yum install -y java-11-openjdk-devel java-11-openjdk-jmods && \
     sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \
     yum clean all -y && rm -rf /var/cache/yum && \
     chmod ug+x /home/jenkins/use-j17.sh && \
     chmod ug+x /home/jenkins/use-j11.sh && \
+    echo "--- STARTS JDK 11/17 TESTS ---" && \
+    /home/jenkins/use-j17.sh && \
     /home/jenkins/use-j11.sh && \
-    echo $JAVA_HOME
+    echo "--- ENDS JDK 11/17 TESTS ---"
+
 
 # Install Maven
 ENV MAVEN_VERSION=3.5.4

--- a/common/jenkins-agents/maven/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/maven/docker/Dockerfile.ubi8
@@ -30,7 +30,8 @@ COPY use-j*.sh /home/jenkins/
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
 COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
-RUN yum install -y java-17-openjdk-devel java-11-openjdk-devel maven-3.5.4 && \
+RUN yum -y update && \
+    yum install -y java-17-openjdk-devel java-11-openjdk-devel maven-3.5.4 && \
     yum install -y java-17-openjdk-jmods java-11-openjdk-jmods && \
     yum clean all -y && rm -rf /var/cache/yum && \
     chmod ug+x /home/jenkins/use-j17.sh && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/maven/docker/Dockerfile.ubi8
@@ -30,7 +30,7 @@ COPY use-j*.sh /home/jenkins/
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
 RUN yum -y --nobest --skip-broken update && \
-    yum install -y java-11-openjdk-devel java-11-openjdk-jmods maven-3.5.4 && \
+    yum install -y java-11-openjdk-devel maven-3.5.4 && \
     sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \
     yum clean all -y && rm -rf /var/cache/yum && \
     chmod ug+x /home/jenkins/use-j17.sh && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/maven/docker/Dockerfile.ubi8
@@ -24,6 +24,19 @@ ENV LANG=en_US.UTF-8 \
 # Container support is now integrated in Java 11, the +UseCGroupMemoryLimitForHeap option has been pruned
 ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true"
 
+# Workaroud we use when running behind proxy
+# Basically we put the proxy certificate in certs folder
+# COPY certs/* /etc/pki/ca-trust/source/anchors/
+# RUN update-ca-trust force-enable && update-ca-trust extract
+
+
+COPY yum.repos.d/* /etc/yum.repos.d/
+RUN grep -ri '^\s*\(name\|enabled\)\s*=' /etc/yum.repos.d/* && \
+    sh -c "echo 'rhel' > /etc/yum/vars/osname" && \
+    sed -i 's@^\s*enabled\s*=.*$@enabled = 1@g' /etc/yum.repos.d/*.repo && \
+    sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/centos8.repo && \
+    sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/adoptium-temurin.repo
+
 # Copy use java scripts.
 COPY use-j*.sh /home/jenkins/
 
@@ -31,11 +44,17 @@ COPY use-j*.sh /home/jenkins/
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
 RUN yum -y --nobest --skip-broken update && \
     yum install -y java-11-openjdk-devel maven-3.5.4 && \
+    yum install -y --enablerepo Adoptium temurin-17-jdk && \
+    yum updateinfo -y && \
+    yum repolist -y && \
     sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \
     yum clean all -y && rm -rf /var/cache/yum && \
     chmod ug+x /home/jenkins/use-j17.sh && \
     chmod ug+x /home/jenkins/use-j11.sh && \
+    echo "--- STARTS JDK 11/17 TESTS ---" && \
+    /home/jenkins/use-j17.sh && \
     /home/jenkins/use-j11.sh && \
+    echo "--- ENDS JDK 11/17 TESTS ---" && \
     mkdir -p $HOME/.m2 && \
     mkdir -p $GRADLE_USER_HOME && mkdir -p /tmp/gradle/wrapper && \
     mvn -v

--- a/common/jenkins-agents/maven/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/maven/docker/Dockerfile.ubi8
@@ -37,9 +37,6 @@ RUN sh -c "echo 'rhel' > /etc/yum/vars/osname" && \
     sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/adoptium-temurin.repo && \
     grep -ri '^\s*\(name\|enabled\)\s*=' /etc/yum.repos.d/*
 
-# Copy use java scripts.
-COPY use-j*.sh /home/jenkins/
-
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
 RUN yum -y --nobest --skip-broken update && \
@@ -48,23 +45,28 @@ RUN yum -y --nobest --skip-broken update && \
     yum updateinfo -y && \
     yum repolist -y && \
     sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \
-    yum clean all -y && rm -rf /var/cache/yum && \
-    chmod ug+x /home/jenkins/use-j17.sh && \
-    chmod ug+x /home/jenkins/use-j11.sh && \
+    yum clean all -y && rm -rf /var/cache/yum
+
+# Copy use java scripts.
+COPY use-j*.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/use-j*.sh && \
+    chmod ugo+s /usr/local/bin/use-j*.sh && \
+    sh -c 'chmod ugo+s $(which alternatives)' && \
+    ls -la /usr/local/bin/use-j*.sh && \
     echo "--- STARTS JDK 11/17 TESTS ---" && \
-    /home/jenkins/use-j17.sh && \
-    /home/jenkins/use-j11.sh && \
-    echo "--- ENDS JDK 11/17 TESTS ---" && \
-    mkdir -p $HOME/.m2 && \
-    mkdir -p $GRADLE_USER_HOME && mkdir -p /tmp/gradle/wrapper && \
-    mvn -v
+    use-j17.sh && \
+    use-j11.sh && \
+    echo "--- ENDS JDK 11/17 TESTS ---"
 
 ADD contrib/settings.xml $HOME/.m2/
 
 COPY set_maven_proxy.sh /tmp/set_maven_proxy.sh
 COPY set_gradle_proxy.sh /tmp/set_gradle_proxy.sh
 
-RUN chmod +x /tmp/set_maven_proxy.sh && \
+RUN mkdir -p $HOME/.m2 && \
+    mkdir -p $GRADLE_USER_HOME && mkdir -p /tmp/gradle/wrapper && \
+    mvn -v && \
+    chmod +x /tmp/set_maven_proxy.sh && \
     chmod +x /tmp/set_gradle_proxy.sh && \
     mv $HOME/.m2/settings.xml $HOME/.m2/settings.xml.orig && \
     /tmp/set_maven_proxy.sh && \
@@ -81,6 +83,7 @@ RUN chmod +x /tmp/set_maven_proxy.sh && \
 ADD gradlew /tmp/gradlew
 ADD gradle/* /tmp/gradle/wrapper
 RUN ls /tmp/gradle/wrapper && \
+    mkdir -pv $GRADLE_USER_HOME && \
     /tmp/set_gradle_proxy.sh && \
     /tmp/gradlew -version
 
@@ -88,7 +91,7 @@ RUN ls /tmp/gradle/wrapper && \
 RUN bash -l -c 'echo export JAVA_OPTS="$(/tmp/set_java_proxy.sh && echo $JAVA_OPTS)" >> /etc/bash.bashrc'
 
 RUN chown -R 1001:0 $HOME && \
-    chown 1001:0 $HOME/use-j*.sh && \
-    chmod -R g+rw $HOME
-
+    chmod -R g+rw $HOME && \
+    chmod -c 666 /etc/pki/ca-trust/extracted/java/cacerts && \
+    ls -la /etc/pki/ca-trust/extracted/java/cacerts
 USER 1001

--- a/common/jenkins-agents/maven/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/maven/docker/Dockerfile.ubi8
@@ -30,7 +30,7 @@ COPY use-j*.sh /home/jenkins/
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
 COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
-RUN yum -y --nobest update && \
+RUN yum -y --nobest --skip-broken update && \
     yum install -y java-17-openjdk-devel java-11-openjdk-devel maven-3.5.4 && \
     yum install -y java-17-openjdk-jmods java-11-openjdk-jmods && \
     yum clean all -y && rm -rf /var/cache/yum && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/maven/docker/Dockerfile.ubi8
@@ -30,7 +30,7 @@ COPY use-j*.sh /home/jenkins/
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
 COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
-RUN yum -y update && \
+RUN yum -y --nobest update && \
     yum install -y java-17-openjdk-devel java-11-openjdk-devel maven-3.5.4 && \
     yum install -y java-17-openjdk-jmods java-11-openjdk-jmods && \
     yum clean all -y && rm -rf /var/cache/yum && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/maven/docker/Dockerfile.ubi8
@@ -84,8 +84,11 @@ ADD gradlew /tmp/gradlew
 ADD gradle/* /tmp/gradle/wrapper
 RUN ls /tmp/gradle/wrapper && \
     mkdir -pv $GRADLE_USER_HOME && \
-    /tmp/set_gradle_proxy.sh && \
-    /tmp/gradlew -version
+    /tmp/set_gradle_proxy.sh
+
+RUN /tmp/gradlew -version && \
+    sh -c "source use-j17.sh && /tmp/gradlew -version" && \
+    sh -c "source use-j11.sh && /tmp/gradlew -version"
 
 # Set java proxy via JAVA_OPTS
 RUN bash -l -c 'echo export JAVA_OPTS="$(/tmp/set_java_proxy.sh && echo $JAVA_OPTS)" >> /etc/bash.bashrc'

--- a/common/jenkins-agents/maven/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/maven/docker/Dockerfile.ubi8
@@ -40,11 +40,12 @@ RUN sh -c "echo 'rhel' > /etc/yum/vars/osname" && \
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
 RUN yum -y --nobest --skip-broken update && \
-    yum install -y java-11-openjdk-devel maven-3.5.4 && \
+    yum install -y java-11-openjdk-devel && \
     yum install -y --enablerepo Adoptium temurin-17-jdk && \
+    yum install -y --enablerepo centos-appstream maven-3.5.4 && \
     yum updateinfo -y && \
     yum repolist -y && \
-    sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \
+    sh -c "yum list installed | grep -i '\(java\|jdk\|temurin\|maven\)'" && \
     yum clean all -y && rm -rf /var/cache/yum
 
 # Copy use java scripts.
@@ -65,7 +66,7 @@ COPY set_gradle_proxy.sh /tmp/set_gradle_proxy.sh
 
 RUN mkdir -p $HOME/.m2 && \
     mkdir -p $GRADLE_USER_HOME && mkdir -p /tmp/gradle/wrapper && \
-    mvn -v && \
+    sh -c "mvn -v || echo 'ERROR: Problem getting maven version'" && \
     chmod +x /tmp/set_maven_proxy.sh && \
     chmod +x /tmp/set_gradle_proxy.sh && \
     mv $HOME/.m2/settings.xml $HOME/.m2/settings.xml.orig && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/maven/docker/Dockerfile.ubi8
@@ -29,10 +29,9 @@ COPY use-j*.sh /home/jenkins/
 
 # Install Maven & java 11 and java 17
 # Note: use java scripts are executed to test the scripts but also use-j11.sh in called 2nd place to set is as default version
-COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
 RUN yum -y --nobest --skip-broken update && \
-    yum install -y java-17-openjdk-devel java-11-openjdk-devel maven-3.5.4 && \
-    yum install -y java-17-openjdk-jmods java-11-openjdk-jmods && \
+    yum install -y java-11-openjdk-devel java-11-openjdk-jmods maven-3.5.4 && \
+    sh -c "yum list installed | grep -i '\(java\|jdk\)'" && \
     yum clean all -y && rm -rf /var/cache/yum && \
     chmod ug+x /home/jenkins/use-j17.sh && \
     chmod ug+x /home/jenkins/use-j11.sh && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/maven/docker/Dockerfile.ubi8
@@ -35,7 +35,6 @@ RUN yum -y --nobest --skip-broken update && \
     yum clean all -y && rm -rf /var/cache/yum && \
     chmod ug+x /home/jenkins/use-j17.sh && \
     chmod ug+x /home/jenkins/use-j11.sh && \
-    /home/jenkins/use-j17.sh && \
     /home/jenkins/use-j11.sh && \
     mkdir -p $HOME/.m2 && \
     mkdir -p $GRADLE_USER_HOME && mkdir -p /tmp/gradle/wrapper && \

--- a/common/jenkins-agents/maven/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/maven/docker/Dockerfile.ubi8
@@ -31,11 +31,11 @@ ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryM
 
 
 COPY yum.repos.d/* /etc/yum.repos.d/
-RUN grep -ri '^\s*\(name\|enabled\)\s*=' /etc/yum.repos.d/* && \
-    sh -c "echo 'rhel' > /etc/yum/vars/osname" && \
+RUN sh -c "echo 'rhel' > /etc/yum/vars/osname" && \
     sed -i 's@^\s*enabled\s*=.*$@enabled = 1@g' /etc/yum.repos.d/*.repo && \
     sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/centos8.repo && \
-    sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/adoptium-temurin.repo
+    sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/adoptium-temurin.repo && \
+    grep -ri '^\s*\(name\|enabled\)\s*=' /etc/yum.repos.d/*
 
 # Copy use java scripts.
 COPY use-j*.sh /home/jenkins/

--- a/common/jenkins-agents/maven/docker/use-j11.sh
+++ b/common/jenkins-agents/maven/docker/use-j11.sh
@@ -7,11 +7,11 @@ function msg_and_exit() {
 
 echo "Switching to java 11:"
 exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1)
-alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || exit 1
+alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || msg_and_exit "Cannot configure java 11 as the alternative to use for java."
 java -version 2>&1 | grep -q 11 || msg_and_exit "Java version is not 11."
 
 if [ -x /usr/lib/jvm/${exactVersion}/bin/javac ]; then
-  alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || exit 1
+  alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || msg_and_exit "Cannot configure javac 11 as the alternative to use for javac."
   javac -version 2>&1 | grep -q 11 || msg_and_exit "Javac version is not 11."
 fi
 

--- a/common/jenkins-agents/maven/docker/use-j11.sh
+++ b/common/jenkins-agents/maven/docker/use-j11.sh
@@ -1,6 +1,10 @@
+#!/bin/bash
+
 echo "Switching to java 11:"
 exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1) && \
 alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java && \
 alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac && \
 java -version
 javac -version
+
+echo "JAVA_HOME: $JAVA_HOME"

--- a/common/jenkins-agents/maven/docker/use-j11.sh
+++ b/common/jenkins-agents/maven/docker/use-j11.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
 echo "Switching to java 11:"
-exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1) && \
-alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java && \
-alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac && \
+exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1)
+alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || exit 1
+alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || exit 1
+
+# Check it again
+java -version | grep -q 11 || exit 1
+javac -version | grep -q 11 || exit 1
+
 java -version
 javac -version
-
 echo "JAVA_HOME: $JAVA_HOME"

--- a/common/jenkins-agents/maven/docker/use-j11.sh
+++ b/common/jenkins-agents/maven/docker/use-j11.sh
@@ -1,24 +1,38 @@
 #!/bin/bash
 
+JAVA_HOME_FOLDER=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1)
+JAVA_VERSION="11"
+
 function msg_and_exit() {
   echo "ERROR: ${1}"
   exit 1
 }
 
-echo "Switching to java 11:"
-exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1)
-alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || msg_and_exit "Cannot configure java 11 as the alternative to use for java."
-java -version 2>&1 | grep -q 11 || msg_and_exit "Java version is not 11."
+echo "Switching to java ${JAVA_VERSION}:"
+JAVA_HOME="/usr/lib/jvm/${JAVA_HOME_FOLDER}"
 
-if [ -x /usr/lib/jvm/${exactVersion}/bin/javac ]; then
-  alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || msg_and_exit "Cannot configure javac 11 as the alternative to use for javac."
-  javac -version 2>&1 | grep -q 11 || msg_and_exit "Javac version is not 11."
+alternatives --set java ${JAVA_HOME}/bin/java || \
+  msg_and_exit "Cannot configure java ${JAVA_VERSION} as the alternative to use for java."
+java -version 2>&1 | grep -q "\s\+${JAVA_VERSION}" || msg_and_exit "Java version is not ${JAVA_VERSION}."
+
+if [ -x ${JAVA_HOME}/bin/javac ]; then
+  alternatives --set javac ${JAVA_HOME}/bin/javac || \
+    msg_and_exit "Cannot configure javac ${JAVA_VERSION} as the alternative to use for javac."
+  javac -version 2>&1 | grep -q "\s\+${JAVA_VERSION}" || msg_and_exit "Javac version is not ${JAVA_VERSION}."
+else
+  echo "WARNING: Not found binary for javac in path ${JAVA_HOME}/bin/javac "
 fi
 
-java -version
+java -version 2>&1
 if which 'javac'; then
-  javac -version
+  javac -version 2>&1
 else
   echo "WARNING: Binary javac is not available."
+fi
+
+if [ -d ${JAVA_HOME}/bin/ ]; then
+  export JAVA_HOME
+else
+  msg_and_exit "Cannot configure JAVA_HOME environment variable to ${JAVA_HOME}"
 fi
 echo "JAVA_HOME: $JAVA_HOME"

--- a/common/jenkins-agents/maven/docker/use-j11.sh
+++ b/common/jenkins-agents/maven/docker/use-j11.sh
@@ -3,11 +3,12 @@
 echo "Switching to java 11:"
 exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1)
 alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || exit 1
-alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || exit 1
-
-# Check it again
 java -version | grep -q 11 || exit 1
-javac -version | grep -q 11 || exit 1
+
+if [ -x /usr/lib/jvm/${exactVersion}/bin/javac ]; then
+  alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || exit 1
+  javac -version | grep -q 11 || exit 1
+fi
 
 java -version
 javac -version

--- a/common/jenkins-agents/maven/docker/use-j11.sh
+++ b/common/jenkins-agents/maven/docker/use-j11.sh
@@ -11,5 +11,9 @@ if [ -x /usr/lib/jvm/${exactVersion}/bin/javac ]; then
 fi
 
 java -version
-javac -version
+if which javac; then
+  javac -version
+else
+  echo "Binary javac is not available."
+fi
 echo "JAVA_HOME: $JAVA_HOME"

--- a/common/jenkins-agents/maven/docker/use-j11.sh
+++ b/common/jenkins-agents/maven/docker/use-j11.sh
@@ -1,19 +1,24 @@
 #!/bin/bash
 
+function msg_and_exit() {
+  echo "ERROR: ${1}"
+  exit 1
+}
+
 echo "Switching to java 11:"
 exactVersion=$(ls -lah /usr/lib/jvm | grep "java-11-openjdk-11.*\.x86_64" | awk '{print $NF}' | head -1)
 alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || exit 1
-java -version | grep -q 11 || exit 1
+java -version 2>&1 | grep -q 11 || msg_and_exit "Java version is not 11."
 
 if [ -x /usr/lib/jvm/${exactVersion}/bin/javac ]; then
   alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || exit 1
-  javac -version | grep -q 11 || exit 1
+  javac -version 2>&1 | grep -q 11 || msg_and_exit "Javac version is not 11."
 fi
 
 java -version
-if which javac; then
+if which 'javac'; then
   javac -version
 else
-  echo "Binary javac is not available."
+  echo "WARNING: Binary javac is not available."
 fi
 echo "JAVA_HOME: $JAVA_HOME"

--- a/common/jenkins-agents/maven/docker/use-j17.sh
+++ b/common/jenkins-agents/maven/docker/use-j17.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo "JDK 17 does not work in centos 7. Sorry!!"
+exit 0
+
 echo "Switching to java 17:"
 exactVersion=$(ls -lah /usr/lib/jvm | grep "java-17-openjdk-17.*\.x86_64" | awk '{print $NF}' | head -1)
 alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || exit 1

--- a/common/jenkins-agents/maven/docker/use-j17.sh
+++ b/common/jenkins-agents/maven/docker/use-j17.sh
@@ -6,7 +6,7 @@ function msg_and_exit() {
 }
 
 echo "Switching to java 17:"
-exactVersion=$(ls -lah /usr/lib/jvm | grep "java-17-openjdk-17.*\.x86_64" | awk '{print $NF}' | head -1)
+exactVersion=$(ls -lah /usr/lib/jvm | grep "temurin-17" | awk '{print $NF}' | head -1)
 alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || msg_and_exit "Cannot configure java 17 as the alternative to use for java."
 java -version 2>&1 | grep -q 17 || msg_and_exit "Java version is not 17."
 

--- a/common/jenkins-agents/maven/docker/use-j17.sh
+++ b/common/jenkins-agents/maven/docker/use-j17.sh
@@ -1,24 +1,38 @@
 #!/bin/bash
 
+JAVA_HOME_FOLDER=$(ls -lah /usr/lib/jvm | grep "temurin-17" | awk '{print $NF}' | head -1)
+JAVA_VERSION="17"
+
 function msg_and_exit() {
   echo "ERROR: ${1}"
   exit 1
 }
 
-echo "Switching to java 17:"
-exactVersion=$(ls -lah /usr/lib/jvm | grep "temurin-17" | awk '{print $NF}' | head -1)
-alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || msg_and_exit "Cannot configure java 17 as the alternative to use for java."
-java -version 2>&1 | grep -q 17 || msg_and_exit "Java version is not 17."
+echo "Switching to java ${JAVA_VERSION}:"
+JAVA_HOME="/usr/lib/jvm/${JAVA_HOME_FOLDER}"
 
-if [ -x /usr/lib/jvm/${exactVersion}/bin/javac ]; then
-  alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || msg_and_exit "Cannot configure javac 17 as the alternative to use for javac."
-  javac -version 2>&1 | grep -q 17 || msg_and_exit "Javac version is not 17."
+alternatives --set java ${JAVA_HOME}/bin/java || \
+  msg_and_exit "Cannot configure java ${JAVA_VERSION} as the alternative to use for java."
+java -version 2>&1 | grep -q "\s\+${JAVA_VERSION}" || msg_and_exit "Java version is not ${JAVA_VERSION}."
+
+if [ -x ${JAVA_HOME}/bin/javac ]; then
+  alternatives --set javac ${JAVA_HOME}/bin/javac || \
+    msg_and_exit "Cannot configure javac ${JAVA_VERSION} as the alternative to use for javac."
+  javac -version 2>&1 | grep -q "\s\+${JAVA_VERSION}" || msg_and_exit "Javac version is not ${JAVA_VERSION}."
+else
+  echo "WARNING: Not found binary for javac in path ${JAVA_HOME}/bin/javac "
 fi
 
-java -version
+java -version 2>&1
 if which 'javac'; then
-  javac -version
+  javac -version 2>&1
 else
   echo "WARNING: Binary javac is not available."
+fi
+
+if [ -d ${JAVA_HOME}/bin/ ]; then
+  export JAVA_HOME
+else
+  msg_and_exit "Cannot configure JAVA_HOME environment variable to ${JAVA_HOME}"
 fi
 echo "JAVA_HOME: $JAVA_HOME"

--- a/common/jenkins-agents/maven/docker/use-j17.sh
+++ b/common/jenkins-agents/maven/docker/use-j17.sh
@@ -7,11 +7,11 @@ function msg_and_exit() {
 
 echo "Switching to java 17:"
 exactVersion=$(ls -lah /usr/lib/jvm | grep "java-17-openjdk-17.*\.x86_64" | awk '{print $NF}' | head -1)
-alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || exit 1
+alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || msg_and_exit "Cannot configure java 17 as the alternative to use for java."
 java -version 2>&1 | grep -q 17 || msg_and_exit "Java version is not 17."
 
 if [ -x /usr/lib/jvm/${exactVersion}/bin/javac ]; then
-  alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || exit 1
+  alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || msg_and_exit "Cannot configure javac 17 as the alternative to use for javac."
   javac -version 2>&1 | grep -q 17 || msg_and_exit "Javac version is not 17."
 fi
 

--- a/common/jenkins-agents/maven/docker/use-j17.sh
+++ b/common/jenkins-agents/maven/docker/use-j17.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-echo "JDK 17 does not work in centos 7. Sorry!!"
-exit 0
-
 echo "Switching to java 17:"
 exactVersion=$(ls -lah /usr/lib/jvm | grep "java-17-openjdk-17.*\.x86_64" | awk '{print $NF}' | head -1)
 alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || exit 1
 alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || exit 1
+
+# Check it again
 java -version | grep -q 17 || exit 1
 javac -version | grep -q 17 || exit 1
 
+java -version
+javac -version
 echo "JAVA_HOME: $JAVA_HOME"

--- a/common/jenkins-agents/maven/docker/use-j17.sh
+++ b/common/jenkins-agents/maven/docker/use-j17.sh
@@ -11,5 +11,9 @@ if [ -x /usr/lib/jvm/${exactVersion}/bin/javac ]; then
 fi
 
 java -version
-javac -version
+if which javac; then
+  javac -version
+else
+  echo "Binary javac is not available."
+fi
 echo "JAVA_HOME: $JAVA_HOME"

--- a/common/jenkins-agents/maven/docker/use-j17.sh
+++ b/common/jenkins-agents/maven/docker/use-j17.sh
@@ -3,11 +3,12 @@
 echo "Switching to java 17:"
 exactVersion=$(ls -lah /usr/lib/jvm | grep "java-17-openjdk-17.*\.x86_64" | awk '{print $NF}' | head -1)
 alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || exit 1
-alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || exit 1
-
-# Check it again
 java -version | grep -q 17 || exit 1
-javac -version | grep -q 17 || exit 1
+
+if [ -x /usr/lib/jvm/${exactVersion}/bin/javac ]; then
+  alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || exit 1
+  javac -version | grep -q 17 || exit 1
+fi
 
 java -version
 javac -version

--- a/common/jenkins-agents/maven/docker/use-j17.sh
+++ b/common/jenkins-agents/maven/docker/use-j17.sh
@@ -1,19 +1,24 @@
 #!/bin/bash
 
+function msg_and_exit() {
+  echo "ERROR: ${1}"
+  exit 1
+}
+
 echo "Switching to java 17:"
 exactVersion=$(ls -lah /usr/lib/jvm | grep "java-17-openjdk-17.*\.x86_64" | awk '{print $NF}' | head -1)
 alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || exit 1
-java -version | grep -q 17 || exit 1
+java -version 2>&1 | grep -q 17 || msg_and_exit "Java version is not 17."
 
 if [ -x /usr/lib/jvm/${exactVersion}/bin/javac ]; then
   alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || exit 1
-  javac -version | grep -q 17 || exit 1
+  javac -version 2>&1 | grep -q 17 || msg_and_exit "Javac version is not 17."
 fi
 
 java -version
-if which javac; then
+if which 'javac'; then
   javac -version
 else
-  echo "Binary javac is not available."
+  echo "WARNING: Binary javac is not available."
 fi
 echo "JAVA_HOME: $JAVA_HOME"

--- a/common/jenkins-agents/maven/docker/use-j17.sh
+++ b/common/jenkins-agents/maven/docker/use-j17.sh
@@ -1,6 +1,10 @@
+#!/bin/bash
+
 echo "Switching to java 17:"
-exactVersion=$(ls -lah /usr/lib/jvm | grep "java-17-openjdk-17.*\.x86_64" | awk '{print $NF}' | head -1) && \
-alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java && \
-alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac && \
-java -version
-javac -version
+exactVersion=$(ls -lah /usr/lib/jvm | grep "java-17-openjdk-17.*\.x86_64" | awk '{print $NF}' | head -1)
+alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java || exit 1
+alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac || exit 1
+java -version | grep -q 17 || exit 1
+javac -version | grep -q 17 || exit 1
+
+echo "JAVA_HOME: $JAVA_HOME"

--- a/common/jenkins-agents/maven/docker/yum.repos.d/adoptium-temurin.repo
+++ b/common/jenkins-agents/maven/docker/yum.repos.d/adoptium-temurin.repo
@@ -1,0 +1,6 @@
+[Adoptium]
+name=Adoptium
+baseurl=https://packages.adoptium.net/artifactory/rpm/$osname/$releasever/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public

--- a/common/jenkins-agents/nodejs12/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/nodejs12/docker/Dockerfile.ubi8
@@ -19,12 +19,21 @@ ENV NODEJS_VERSION=12 \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
+ENV INSTALL_PKGS="make gcc-c++ GConf2 nss libXScrnSaver alsa-lib "
+ENV INSTALL_CENTOS_PKGS="nodejs nodejs-nodemon xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel"
+
 # Workaroud we use when running behind proxy
 # Basically we put the proxy certificate in certs folder
-# COPY certs/* /etc/pki/ca-trust/source/anchors/
-# RUN update-ca-trust force-enable && update-ca-trust extract
+COPY certs/* /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust force-enable && update-ca-trust extract
 
 COPY contrib/bin/configure-agent /usr/local/bin/configure-agent
+
+COPY yum.repos.d/*.repo /etc/yum.repos.d/
+RUN sed -i 's@^\s*enabled\s*=.*$@enabled = 1@g' /etc/yum.repos.d/*.repo \
+    && sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/centos*.repo \
+    && sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/google-chrome*.repo \
+    && grep -i '\(name\|enabled\)' /etc/yum.repos.d/*.repo
 
 # Install Python 3 (because node-gyp, an ionic dependency, uses it) and set it as default
 RUN yum install -y python3 python3-pip || true
@@ -36,23 +45,19 @@ RUN bash -c "python -V 2>&1 | grep -q 'Python 3.*' || update-alternatives --inst
 RUN dbus-uuidgen > /etc/machine-id
 
 # Install NodeJS (https://rpm.nodesource.com/setup_12.x does NOT work)
-RUN INSTALL_PKGS="nodejs nodejs-nodemon make gcc-c++" && \
+RUN yum install -y $INSTALL_PKGS && \
     yum module enable -y nodejs:${NODEJS_VERSION} && \
-    yum install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    yum clean all -y
+    yum install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager --enablerepo centos-appstream $INSTALL_CENTOS_PKGS && \
+    rpm -V $INSTALL_PKGS
 
 # Install Yarn
 # https://classic.yarnpkg.com/en/docs/install
-RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
+RUN curl -o- -sSL https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
 
 # Install Cypress dependencies
 # https://docs.cypress.io/guides/getting-started/installing-cypress.html#System-requirements
-COPY yum.repos.d/google-chrome.repo /etc/yum.repos.d/google-chrome.repo
-COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
 RUN yum repolist \
-    && yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib \
-    && yum install -y --enablerepo google-chrome google-chrome-stable \
+    && yum install -y --enablerepo google-chrome --enablerepo centos-appstream --enablerepo centos-baseos google-chrome-stable \
     && yum clean all -y
 
 RUN npm config set registry=$nexusUrl/repository/npmjs/ && \

--- a/common/jenkins-agents/nodejs12/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/nodejs12/docker/Dockerfile.ubi8
@@ -24,8 +24,8 @@ ENV INSTALL_CENTOS_PKGS="nodejs nodejs-nodemon xorg-x11-server-Xvfb gtk2-devel g
 
 # Workaroud we use when running behind proxy
 # Basically we put the proxy certificate in certs folder
-COPY certs/* /etc/pki/ca-trust/source/anchors/
-RUN update-ca-trust force-enable && update-ca-trust extract
+# COPY certs/* /etc/pki/ca-trust/source/anchors/
+# RUN update-ca-trust force-enable && update-ca-trust extract
 
 COPY contrib/bin/configure-agent /usr/local/bin/configure-agent
 

--- a/common/jenkins-agents/nodejs12/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/nodejs12/docker/Dockerfile.ubi8
@@ -19,7 +19,18 @@ ENV NODEJS_VERSION=12 \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
+# Workaroud we use when running behind proxy
+# Basically we put the proxy certificate in certs folder
+# COPY certs/* /etc/pki/ca-trust/source/anchors/
+# RUN update-ca-trust force-enable && update-ca-trust extract
+
 COPY contrib/bin/configure-agent /usr/local/bin/configure-agent
+
+# Install Python 3 (because node-gyp, an ionic dependency, uses it) and set it as default
+RUN yum install -y python3 python3-pip || true
+# update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
+RUN bash -c "python -V 2>&1 | grep -q 'Python 3.*' || update-alternatives --install /usr/bin/python python /usr/bin/python3 1 " && \
+    bash -c "python -V 2>&1 | grep 'Python 3.*' || echo 'ERROR: Invalid python version'"
 
 # Generate machine ID
 RUN dbus-uuidgen > /etc/machine-id

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -36,6 +36,11 @@ ENV HOME=/home/jenkins
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 COPY python_requirements /tmp/requirements.txt
 
+# Workaroud we use when running behind proxy
+# Basically we put the proxy certificate in certs folder
+# COPY certs/* /etc/pki/ca-trust/source/anchors/
+# RUN update-ca-trust force-enable && update-ca-trust extract
+
 COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
 RUN sed -i 's@^\s*enabled\s*=.*$@enabled = 1@g' /etc/yum.repos.d/*.repo \
     && sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/centos8.repo \

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -28,12 +28,12 @@ ENV RBENV_ROOT /opt/rbenv
 ENV RBENV_SHELL bash
 
 ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch readline \
-    libffi-devel openssl-devel make bzip2 autoconf automake libtool curl sqlite-devel xz"
-ENV INSTALL_CENTOS_PKGS="readline-devel bison"
+    libffi-devel openssl-devel make bzip2 autoconf curl sqlite-devel xz"
+ENV INSTALL_CENTOS_PKGS="readline-devel bison automake libtool"
 ENV PATH=/opt/tfenv/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
 ENV HOME=/home/jenkins
 
-RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+RUN sh -c "rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true"
 COPY python_requirements /tmp/requirements.txt
 
 # Workaroud we use when running behind proxy

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -118,8 +118,7 @@ RUN wget -q -O /tmp/terraform-docs.tar.gz https://github.com/terraform-docs/terr
 # Install jq
 RUN yum install -y jq parallel \
     && jq -Version \
-    && yum clean all \
-    && yum-config-manager -t --disable epel epel-modular
+    && yum clean all
 
 # Install consul-cli
 RUN wget -q "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip" \

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -32,7 +32,7 @@ ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch read
 ENV PATH=/opt/tfenv/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
 ENV HOME=/home/jenkins
 
-COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 COPY python_requirements /tmp/requirements.txt
 
 RUN set -x \
@@ -106,11 +106,10 @@ RUN wget -q -O /tmp/terraform-docs.tar.gz https://github.com/terraform-docs/terr
     && chmod +x /usr/local/bin/terraform-docs
 
 # Install jq
-RUN yum -y install epel-release \
-    && yum install -y jq parallel \
+RUN yum install -y jq parallel \
     && jq -Version \
     && yum clean all \
-    && yum-config-manager --disable epel
+    && yum-config-manager -t --disable epel epel-modular
 
 # Install consul-cli
 RUN wget -q "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip" \

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -27,18 +27,28 @@ ENV GEM_HOME /opt/bundle
 ENV RBENV_ROOT /opt/rbenv
 ENV RBENV_SHELL bash
 
-ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch readline readline-devel \
-    libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel xz"
+ENV INSTALL_PKGS="yum-utils gcc make git-core zlib zlib-devel gcc-c++ patch readline \
+    libffi-devel openssl-devel make bzip2 autoconf automake libtool curl sqlite-devel xz"
+ENV INSTALL_CENTOS_PKGS="readline-devel bison"
 ENV PATH=/opt/tfenv/bin:/opt/rbenv/shims:/opt/rbenv/bin:/opt/node/bin:$PATH
 ENV HOME=/home/jenkins
 
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 COPY python_requirements /tmp/requirements.txt
 
-RUN set -x \
-    && dnf -y install $INSTALL_PKGS
+COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
+RUN sed -i 's@^\s*enabled\s*=.*$@enabled = 1@g' /etc/yum.repos.d/*.repo \
+    && sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/centos8.repo \
+    && sed -i 's@^\s*gpgcheck\s*=.*$@gpgcheck = 0@g' /etc/yum.repos.d/centos8.repo \
+    && grep -i '\(name\|enabled\)' /etc/yum.repos.d/*.repo
 
-RUN curl "https://bootstrap.pypa.io/pip/3.6/get-pip.py" -o "get-pip.py" \
+RUN set -x \
+    && dnf -y repolist \
+    && dnf -y install $INSTALL_PKGS \
+    && dnf -y install --enablerepo centos-base --enablerepo centos-plus --enablerepo centos-extras \
+                      --enablerepo centos-appstream --enablerepo centos-devel $INSTALL_CENTOS_PKGS
+
+RUN curl -sSL "https://bootstrap.pypa.io/pip/3.6/get-pip.py" -o "get-pip.py" \
     && python3 get-pip.py
 
 # Upgrade PIP
@@ -54,7 +64,7 @@ RUN pip config set global.cert /etc/ssl/certs/ca-bundle.crt \
 RUN python3 -m pip install -r /tmp/requirements.txt
 
 # Install awscli2
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+RUN curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip -qq awscliv2.zip \
     && ./aws/install \
     && rm -f awscliv2.zip \

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -39,7 +39,6 @@ COPY python_requirements /tmp/requirements.txt
 COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
 RUN sed -i 's@^\s*enabled\s*=.*$@enabled = 1@g' /etc/yum.repos.d/*.repo \
     && sed -i 's@^\s*enabled\s*=.*$@enabled = 0@g' /etc/yum.repos.d/centos8.repo \
-    && sed -i 's@^\s*gpgcheck\s*=.*$@gpgcheck = 0@g' /etc/yum.repos.d/centos8.repo \
     && grep -i '\(name\|enabled\)' /etc/yum.repos.d/*.repo
 
 RUN set -x \

--- a/common/jenkins-agents/terraform/docker/yum.repos.d/centos8.repo
+++ b/common/jenkins-agents/terraform/docker/yum.repos.d/centos8.repo
@@ -1,21 +1,46 @@
-[centos-baseos]
-name=CentOS-8-BaseOS
+[centos-base]
+name=CentOS-8 - Base
+#mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=os&infra=centos
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
 baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
-enabled=1
 gpgcheck=1
-gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=0
+
+#additional packages that may be useful
+[centos-extras]
+name=CentOS-8 - Extras
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+baseurl=http://mirror.centos.org/centos/8-stream/extras/x86_64/os/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=0
+
+#additional packages that extend functionality of existing packages
+[centos-plus]
+name=CentOS-8 - Plus
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+baseurl=http://mirror.centos.org/centos/8-stream/centosplus/x86_64/os/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 
 [centos-appstream]
 name=CentOS-8-AppStream
 baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
-enabled=1
+enabled=0
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 
-[centos-extras]
-name=CentOS-8-Extras
-baseurl=http://mirror.centos.org/centos/8-stream/extras/x86_64/os/
-enabled=1
+[centos-devel]
+name=CentOS-8 - Devel
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+baseurl=http://mirror.centos.org/centos/8-stream/Devel/x86_64/os/
 gpgcheck=1
-gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
-
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=0

--- a/common/jenkins-agents/terraform/docker/yum.repos.d/centos8.repo
+++ b/common/jenkins-agents/terraform/docker/yum.repos.d/centos8.repo
@@ -5,7 +5,7 @@ name=CentOS-8 - Base
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
 baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+gpgkey=https://centos.org/keys/RPM-GPG-KEY-CentOS-Official
 enabled=0
 
 #additional packages that may be useful
@@ -15,7 +15,7 @@ name=CentOS-8 - Extras
 #baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
 baseurl=http://mirror.centos.org/centos/8-stream/extras/x86_64/os/
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+gpgkey=https://centos.org/keys/RPM-GPG-KEY-CentOS-Official
 enabled=0
 
 #additional packages that extend functionality of existing packages
@@ -26,7 +26,7 @@ mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo
 baseurl=http://mirror.centos.org/centos/8-stream/centosplus/x86_64/os/
 gpgcheck=1
 enabled=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+gpgkey=https://centos.org/keys/RPM-GPG-KEY-CentOS-Official
 
 [centos-appstream]
 name=CentOS-8-AppStream
@@ -42,5 +42,5 @@ name=CentOS-8 - Devel
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
 baseurl=http://mirror.centos.org/centos/8-stream/Devel/x86_64/os/
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+gpgkey=https://centos.org/keys/RPM-GPG-KEY-CentOS-Official
 enabled=0

--- a/e2e-spock-geb/files/build.gradle
+++ b/e2e-spock-geb/files/build.gradle
@@ -26,19 +26,10 @@ plugins {
 
 repositories {
     if (no_nexus) {
-        println("using repositories 'jcenter' and 'mavenCentral', because property no_nexus=$no_nexus")
-        jcenter()
+        println("using repository 'mavenCentral', because property no_nexus=$no_nexus")
         mavenCentral()
     } else {
         println("using nexus repositories")
-        maven() {
-            url "${nexus_url}/repository/jcenter/"
-            credentials {
-                username = "${nexus_user}"
-                password = "${nexus_pw}"
-            }
-        }
-
         maven() {
             url "${nexus_url}/repository/maven-public/"
             credentials {


### PR DESCRIPTION
The upgrade of the atlassian stack needed some modifications in quickstarters because some bugs appeared.

Tasks: 
- [x] Remove jcenter repositories from quickstarters (Fixes https://github.com/opendevstack/ods-quickstarters/issues/804 ).
- [x] Fix non-working jdk-17 usage (Fixes https://github.com/opendevstack/ods-quickstarters/issues/808 ).
- [x] Full revision of Jenkins Pipelines, to make them work again. Increased timeouts for building quickstarters and added the retrieval of the return status for building each quickstarter.
- [x] UBI8 docker image for terraform is installing packages from centos when it should take the ones available at Red Hat (Fixes https://github.com/opendevstack/ods-quickstarters/issues/813 )
- [x] Upgrade atlassian stack (Implements https://github.com/opendevstack/ods-core/issues/1138 )
