### PR TITLE
Update stage name in all Quickstarters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fix non-working jdk-17 usage (Fixes [#808](https://github.com/opendevstack/ods-quickstarters/issues/808))
 - Full revision of Jenkins Pipelines, to make them work again. Increased timeouts for building quickstarters and added the retrieval of the return status for building each quickstarter.
 - Groovy junit tests cannot be run twice (Fixes [#814](https://github.com/opendevstack/ods-quickstarters/issues/814))
+- Stage name not updated in latest version ([#816](https://github.com/opendevstack/ods-quickstarters/issues/816))
 
 ### Modified
 

--- a/be-gateway-nginx/Jenkinsfile.template
+++ b/be-gateway-nginx/Jenkinsfile.template
@@ -10,7 +10,7 @@ odsComponentPipeline(
   ]
 ) { context ->
 
-  odsComponentStageImportOpenShiftImageOrElse(context) {
+  odsComponentFindOpenShiftImageOrElse(context) {
     odsComponentStageBuildOpenShiftImage(context)
   }
 

--- a/be-golang-plain/Jenkinsfile.template
+++ b/be-golang-plain/Jenkinsfile.template
@@ -9,7 +9,7 @@ odsComponentPipeline(
     // 'release/': 'test'
   ]
 ) { context ->
-  odsComponentStageImportOpenShiftImageOrElse(context) {
+  odsComponentFindOpenShiftImageOrElse(context) {
     stageCheckFormat(context)
     stageLint(context)
     stageUnitTest(context)

--- a/be-java-springboot/Jenkinsfile.template
+++ b/be-java-springboot/Jenkinsfile.template
@@ -9,7 +9,7 @@ odsComponentPipeline(
     // 'release/': 'test'
   ]
 ) { context ->
-  odsComponentStageImportOpenShiftImageOrElse(context) {
+  odsComponentFindOpenShiftImageOrElse(context) {
     stageBuild(context)
     odsComponentStageScanWithSonar(context)
     odsComponentStageBuildOpenShiftImage(context)

--- a/be-python-flask/Jenkinsfile.template
+++ b/be-python-flask/Jenkinsfile.template
@@ -9,7 +9,7 @@ odsComponentPipeline(
     // 'release/': 'test'
   ]
 ) { context ->
-  odsComponentStageImportOpenShiftImageOrElse(context) {
+  odsComponentFindOpenShiftImageOrElse(context) {
     stageTestSuite(context)
     odsComponentStageScanWithSonar(context)
     stageBuild(context)

--- a/be-scala-play/Jenkinsfile.template
+++ b/be-scala-play/Jenkinsfile.template
@@ -11,7 +11,7 @@ odsComponentPipeline(
     // 'release/': 'test'
   ]
 ) { context ->
-  odsComponentStageImportOpenShiftImageOrElse(context) {
+  odsComponentFindOpenShiftImageOrElse(context) {
     stageBuild(context)
     odsComponentStageScanWithSonar(context)
     odsComponentStageBuildOpenShiftImage(context)

--- a/be-typescript-express/Jenkinsfile.template
+++ b/be-typescript-express/Jenkinsfile.template
@@ -9,7 +9,7 @@ odsComponentPipeline(
   // 'release/': 'test'
   ]
 ) { context ->
-  odsComponentStageImportOpenShiftImageOrElse(context) {
+  odsComponentFindOpenShiftImageOrElse(context) {
     stageBuild(context)
     stageUnitTest(context)
     odsComponentStageScanWithSonar(context)

--- a/docker-plain/Jenkinsfile.template
+++ b/docker-plain/Jenkinsfile.template
@@ -9,7 +9,7 @@ odsComponentPipeline(
     // 'release/': 'test'
   ]
 ) { context ->
-  odsComponentStageImportOpenShiftImageOrElse(context) {
+  odsComponentFindOpenShiftImageOrElse(context) {
     stageBuild(context)
     stageUnitTest(context)
     /*

--- a/ds-jupyter-lab/Jenkinsfile.template
+++ b/ds-jupyter-lab/Jenkinsfile.template
@@ -10,7 +10,7 @@ odsComponentPipeline(
   ]
 ) { context ->
 
-  odsComponentStageImportOpenShiftImageOrElse(context) {
+  odsComponentFindOpenShiftImageOrElse(context) {
     odsComponentStageBuildOpenShiftImage(context, [
       buildArgs: [
         nexusHostWithBasicAuth: context.nexusHostWithBasicAuth,

--- a/ds-rshiny/Jenkinsfile.template
+++ b/ds-rshiny/Jenkinsfile.template
@@ -11,7 +11,7 @@ odsComponentPipeline(
   ]
 ) { context ->
 
-  odsComponentStageImportOpenShiftImageOrElse(context) {
+  odsComponentFindOpenShiftImageOrElse(context) {
     odsComponentStageBuildOpenShiftImage(context)
   }
 

--- a/fe-angular/Jenkinsfile.template
+++ b/fe-angular/Jenkinsfile.template
@@ -9,7 +9,7 @@ odsComponentPipeline(
   // 'release/': 'test'
   ]
 ) { context ->
-  odsComponentStageImportOpenShiftImageOrElse(context) {
+  odsComponentFindOpenShiftImageOrElse(context) {
     stageBuild(context)
     stageUnitTest(context)
     odsComponentStageScanWithSonar(context)

--- a/fe-ionic/Jenkinsfile.template
+++ b/fe-ionic/Jenkinsfile.template
@@ -9,7 +9,7 @@ odsComponentPipeline(
   // 'release/': 'test'
   ]
 ) { context ->
-  odsComponentStageImportOpenShiftImageOrElse(context) {
+  odsComponentFindOpenShiftImageOrElse(context) {
     stageBuild(context)
     stageUnitTest(context)
     stageLint(context)


### PR DESCRIPTION
Closes #816 for master

Is there a reason why the mono-repo quickstarter does not had _odsComponentStageImportOpenShiftImageOrElse_ nor _odsComponentFindOpenShiftImageOrElse_ ?
Should we add it ?


