### PR TITLE
Fixes problems with docker container images

### DIFF
--- a/common/jenkins-agents/golang/ocp-config/docker_img_remote_tag.cfg
+++ b/common/jenkins-agents/golang/ocp-config/docker_img_remote_tag.cfg
@@ -1,1 +1,0 @@
-registry.hub.docker.com/victorpablosceruelo1981/ods-qs-golang

--- a/common/jenkins-agents/golang/ocp-config/docker_img_remote_tag.cfg
+++ b/common/jenkins-agents/golang/ocp-config/docker_img_remote_tag.cfg
@@ -1,0 +1,1 @@
+registry.hub.docker.com/victorpablosceruelo1981/ods-qs-golang

--- a/common/jenkins-agents/maven/docker/Dockerfile.centos7
+++ b/common/jenkins-agents/maven/docker/Dockerfile.centos7
@@ -59,6 +59,10 @@ RUN chmod +x /usr/local/bin/use-j*.sh && \
     use-j11.sh && \
     echo "--- ENDS JDK 11/17 TESTS ---"
 
+# Setup the user that will run the jobs.
+RUN groupadd --gid 1001 jenkins && \
+    adduser --base-dir /home --uid 1001 --gid 1001 jenkins
+
 # Install Maven
 ENV MAVEN_VERSION=3.5.4
 ENV BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
@@ -113,7 +117,7 @@ RUN /tmp/gradlew -version && \
 #set java proxy via JAVA_OPTS as src
 RUN bash -l -c 'echo export JAVA_OPTS="$(/tmp/set_java_proxy.sh && echo $JAVA_OPTS)" >> /etc/bash.bashrc'
 
-RUN chown -R 1001:0 $HOME && \
+RUN chown -R jenkins:jenkins $HOME && \
     chmod -R g+rw $HOME && \
     chmod -c 666 /etc/pki/ca-trust/extracted/java/cacerts && \
     ls -la /etc/pki/ca-trust/extracted/java/cacerts

--- a/common/jenkins-agents/nodejs12/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/nodejs12/docker/Dockerfile.ubi8
@@ -24,8 +24,8 @@ ENV INSTALL_CENTOS_PKGS="nodejs nodejs-nodemon xorg-x11-server-Xvfb gtk2-devel g
 
 # Workaroud we use when running behind proxy
 # Basically we put the proxy certificate in certs folder
-COPY certs/* /etc/pki/ca-trust/source/anchors/
-RUN update-ca-trust force-enable && update-ca-trust extract
+# COPY certs/* /etc/pki/ca-trust/source/anchors/
+# RUN update-ca-trust force-enable && update-ca-trust extract
 
 COPY contrib/bin/configure-agent /usr/local/bin/configure-agent
 


### PR DESCRIPTION
nodejs12 agent docker image sometimes fails to reach pkgs it needs to download for installation.
maven agent docker image does not have the user with id / gid  1001 / 1001. Needed for some tasks.

Tasks: 
- [x] Fixes https://github.com/opendevstack/ods-quickstarters/issues/820
- [x] Fixes https://github.com/opendevstack/ods-quickstarters/issues/819
