### PR TITLE
adjust title check in cypress test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Nodejs12 agent docker image sometimes fails to reach pkgs it needs to download for installation. (Fixes [#819](https://github.com/opendevstack/ods-quickstarters/issues/819))
 - Fixes docgen pod assigned memory issue ([#837](https://github.com/opendevstack/ods-quickstarters/pull/837))
 - Update nodejs version in TypeScript Quickstarter ([#834](https://github.com/opendevstack/ods-quickstarters/issues/834))
+- Fix failing acceptance test in cypress quickstarter ([#840](https://github.com/opendevstack/ods-quickstarters/issues/840))
 
 ## [4.0] - 2021-11-05
 

--- a/e2e-cypress/files/tests/acceptance/acceptance.spec.ts
+++ b/e2e-cypress/files/tests/acceptance/acceptance.spec.ts
@@ -6,7 +6,7 @@ describe('acceptance e2e tests', () => {
 
   it('Application is reachable', function () {
     cy.visit('/html/tryit.asp?filename=tryhtml_basic_paragraphs');
-    cy.title().should('include', 'Tryit Editor v3.7');
+    cy.title().should('include', 'Tryit Editor');
     printTestEvidence(this.test.fullTitle(), 1, '#textareaCode', 'code area');
     printTestEvidence(this.test.fullTitle(), 2, '#iframecontainer', 'rendered code area');
   });


### PR DESCRIPTION
The acceptance test for the cypress QS uses an external source for running tests against. The title field of that page seems to have changed and therfore the test is failing now. Currently it is `W3Schools Tryit Editor` without any version number in the name.

BTW this reminds on my comment here https://github.com/opendevstack/ods-quickstarters/pull/502#discussion_r532600193 😜

Fixes #840