### PR TITLE
Cypress update node16 in 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Enforce use of secure Log4j version in SpringBoot Quickstarter ([#693](https://github.com/opendevstack/ods-quickstarters/issues/693))
 - jupyter lab: reduction to a minimal initial env ([#710](https://github.com/opendevstack/ods-quickstarters/issues/710))
 - inf-terraform-agent: consistent use of Python 3.9.x ([#793](https://github.com/opendevstack/ods-quickstarters/pull/793))
+- e2e-cypress: use Node.js 16 for deployment ([#853](https://github.com/opendevstack/ods-quickstarters/issues/853))
 
 ### Fixed
 

--- a/e2e-cypress/Jenkinsfile
+++ b/e2e-cypress/Jenkinsfile
@@ -15,7 +15,7 @@ node {
 library("ods-jenkins-shared-library@${sharedLibraryRef}")
 
 odsQuickstarterPipeline(
-  imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs12:${agentImageTag}",
+  imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs16:${agentImageTag}",
 ) { context ->
 
   odsQuickstarterStageCopyFiles(context)


### PR DESCRIPTION
Switch Node.js agent from version 12 to 16 for provisioning.

Closes #853 for 4.x branch (Cherry-pick from master)


Please note: The provisioned QS used Node.js 16 already before. This updated happened here: #770