### PR TITLE
adjust title check in cypress test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - Update nodejs version in TypeScript Quickstarter ([#834](https://github.com/opendevstack/ods-quickstarters/issues/834))
 - Fix nodejs12 build fails with redhat jenkins agent ([#843](https://github.com/opendevstack/ods-quickstarters/issues/843))
 - Fix Build Terraform UBI agent fails ([#847](https://github.com/opendevstack/ods-quickstarters/issues/847))
+- Fix failing acceptance test in cypress quickstarter ([#840](https://github.com/opendevstack/ods-quickstarters/issues/840))
 
 ## [4.0] - 2021-11-05
 

--- a/e2e-cypress/files/tests/acceptance/acceptance.spec.ts
+++ b/e2e-cypress/files/tests/acceptance/acceptance.spec.ts
@@ -6,7 +6,7 @@ describe('acceptance e2e tests', () => {
 
   it('Application is reachable', function () {
     cy.visit('/html/tryit.asp?filename=tryhtml_basic_paragraphs');
-    cy.title().should('include', 'Tryit Editor v3.7');
+    cy.title().should('include', 'Tryit Editor');
     printTestEvidence(this.test.fullTitle(), 1, '#textareaCode', 'code area');
     printTestEvidence(this.test.fullTitle(), 2, '#iframecontainer', 'rendered code area');
   });


### PR DESCRIPTION
Backport of https://github.com/opendevstack/ods-quickstarters/pull/841 to 4.x.

The acceptance test for the cypress QS uses an external source for running tests against. The title field of that page seems to have changed and therfore the test is failing now. Currently it is W3Schools Tryit Editor without any version number in the name.

Fixes https://github.com/opendevstack/ods-quickstarters/issues/840