### PR TITLE
Upgrade be gateway nginx to rocky 1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - inf-terraform-azure: update Azure QS and agent libraries, Terraform version  ([#856](https://github.com/opendevstack/ods-quickstarters/pull/856))
 - be-python-flask, ds-jupyter-lab: upgrade to python3.9, and keep support of python3.8([#865](https://github.com/opendevstack/ods-quickstarters/issues/865))
 - Remove support for the url repository field in metadata.yml ([#868](https://github.com/opendevstack/ods-quickstarters/pull/868))
+- Upgrade be-gateway-nginx from fedora-rpm to rocky and from version 1.19 to 1.21 ([#880](https://github.com/opendevstack/ods-quickstarters/issues/880))
 
 ### Fixed
 

--- a/be-gateway-nginx/files/docker/Dockerfile
+++ b/be-gateway-nginx/files/docker/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/openresty/docker-openresty
-FROM openresty/openresty:1.19.3.2-fedora-rpm
+FROM openresty/openresty:1.21.4.1-rocky
 
 ENV LANG=C.UTF-8
 


### PR DESCRIPTION
This falls under the general ods-quickstarters maintenance requested by @braisvq1996  

Fixes #880 

Tasks: 
- [x] Updated documentation in `docs/modules/...` directory
- [x] Ran tests in `<quickstarter>/testdata` directory
