### PR TITLE
generate one xml report per spec and merge them later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Generate one xml report per spec and merge them later ([#898](https://github.com/opendevstack/ods-quickstarters/pull/898))
 - Addition of streamlit quickstarter ([#891](https://github.com/opendevstack/ods-quickstarters/issues/891))
 - Removal of Centos agents ([#1209](https://github.com/opendevstack/ods-core/issues/1209))
 - Fix oauth-proxy sidecar image ([#862](https://github.com/opendevstack/ods-quickstarters/issues/862))

--- a/e2e-cypress/files/README.md
+++ b/e2e-cypress/files/README.md
@@ -17,9 +17,9 @@ Run `npm run e2e` to execute all end-to-end tests via [Cypress](https://www.cypr
 Run `npm start` to develop the e2e tests. The tests will automatically rebuild and run, if you change any of the source files. Ideally the test will run against a local instance of the front end, e.g. `http://localhost:4200` for an Angular app. This destination is configurable in the `cypress.json` file.
 
 ## Reports
-From [Merging reports across spec files](https://docs.cypress.io/guides/tooling/reporters#Merging-reports-across-spec-files): each spec file is processed completely separately during each cypress run execution. Thus each spec run overwrites the previous report file. To preserve unique reports for each specfile, use the [hash] in the mochaFile filename.
+From [Merging reports across spec files](https://docs.cypress.io/guides/tooling/reporters#Merging-reports-across-spec-files): each spec file is processed completely separately during each cypress run execution. Thus each spec run overwrites the previous report file. To preserve unique reports for each spec file, use the `[hash]` in the `mochaFile` filename.
 
-In order to generate one xml report per test type (installation, integration and acceptance) we use the junit-report-merger tool. See _junit-*-report_ in package.json.
+In order to generate one xml report per test type (installation, integration and acceptance) we use the junit-report-merger tool. See also the `junit-...-report` tasks in `package.json`.
 
 ## E2e test user authentication
 

--- a/e2e-cypress/files/README.md
+++ b/e2e-cypress/files/README.md
@@ -16,6 +16,11 @@ Run `npm run e2e` to execute all end-to-end tests via [Cypress](https://www.cypr
 
 Run `npm start` to develop the e2e tests. The tests will automatically rebuild and run, if you change any of the source files. Ideally the test will run against a local instance of the front end, e.g. `http://localhost:4200` for an Angular app. This destination is configurable in the `cypress.json` file.
 
+## Reports
+From [Merging reports across spec files](https://docs.cypress.io/guides/tooling/reporters#Merging-reports-across-spec-files): each spec file is processed completely separately during each cypress run execution. Thus each spec run overwrites the previous report file. To preserve unique reports for each specfile, use the [hash] in the mochaFile filename.
+
+In order to generate one xml report per test type (installation, integration and acceptance) we use the junit-report-merger tool. See _junit-*-report_ in package.json.
+
 ## E2e test user authentication
 
 This quickstarter provides a login command for Azure SSO with MSALv2 (`./support/msalv2-login.ts`) as well as sample code for a generic login (`./support/generic-login.ts`). 

--- a/e2e-cypress/files/cypress-acceptance.json
+++ b/e2e-cypress/files/cypress-acceptance.json
@@ -9,6 +9,6 @@
   "video": false,
   "reporter": "junit",
   "reporterOptions": {
-    "mochaFile": "test-results/acceptance-junit.xml"
+    "mochaFile": "test-results/acceptance/junit-[hash].xml"
   }
 }

--- a/e2e-cypress/files/cypress-installation.json
+++ b/e2e-cypress/files/cypress-installation.json
@@ -9,6 +9,6 @@
   "video": false,
   "reporter": "junit",
   "reporterOptions": {
-    "mochaFile": "test-results/installation-junit.xml"
+    "mochaFile": "test-results/installation/junit-[hash].xml"
   }
 }

--- a/e2e-cypress/files/cypress-integration.json
+++ b/e2e-cypress/files/cypress-integration.json
@@ -9,6 +9,6 @@
   "video": false,
   "reporter": "junit",
   "reporterOptions": {
-    "mochaFile": "test-results/integration-junit.xml"
+    "mochaFile": "test-results/integration/junit-[hash].xml"
   }
 }

--- a/e2e-cypress/files/package.json
+++ b/e2e-cypress/files/package.json
@@ -9,13 +9,17 @@
     "cypress:run-installation": "npm run cypress:run -- --config-file cypress-installation.json",
     "cypress:run-integration": "npm run cypress:run -- --config-file cypress-integration.json",
     "cypress:run-acceptance": "npm run cypress:run -- --config-file cypress-acceptance.json",
+    "junit-installation-report": "jrm ./test-results/installation-junit.xml './test-results/installation/*.xml'",
+    "junit-integration-report": "jrm ./test-results/integration-junit.xml './test-results/integration/*.xml'",
+    "junit-acceptance-report": "jrm ./test-results/acceptance-junit.xml './test-results/acceptance/*.xml'",
     "delete-junit-results": "rimraf build/test-results",
-    "e2e": "npm-run-all delete-junit-results cypress:run-installation cypress:run-integration cypress:run-acceptance"
+    "e2e": "npm-run-all delete-junit-results cypress:run-installation cypress:run-integration cypress:run-acceptance junit-installation-report junit-integration-report junit-acceptance-report"
   },
   "private": true,
   "devDependencies": {
     "@types/node": "^17.0.23",
     "cypress": "^9.5.3",
+    "junit-report-merger": "^5.0.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
     "typescript": "^4.6.3"


### PR DESCRIPTION
From [Merging reports across spec files](https://docs.cypress.io/guides/tooling/reporters#Merging-reports-across-spec-files): each spec file is processed completely separately during each cypress run execution. Thus each spec run overwrites the previous report file. To preserve unique reports for each specfile, use the [hash] in the mochaFile filename.

In order to generate one xml report per test type (installation, integration and acceptance) we use the junit-report-merger tool. See _junit-*-report_ in package.json.
