### PR TITLE
change /tmp permissions in inf-terraform-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Removal of Centos agents ([#1209](https://github.com/opendevstack/ods-core/issues/1209))
 - Fix oauth-proxy sidecar image ([#862](https://github.com/opendevstack/ods-quickstarters/issues/862))
 - Upgrade be-gateway-nginx from fedora-rpm to rocky and from version 1.19 to 1.21 ([#880](https://github.com/opendevstack/ods-quickstarters/issues/880))
-- Fix inf-terraform-agent bundler complaining about /tmp permissions ([]())
+- Fix inf-terraform-agent bundler complaining about /tmp permissions ([#903](https://github.com/opendevstack/ods-quickstarters/pull/903))
 
 ## [4.1] - 2022-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Removal of Centos agents ([#1209](https://github.com/opendevstack/ods-core/issues/1209))
 - Fix oauth-proxy sidecar image ([#862](https://github.com/opendevstack/ods-quickstarters/issues/862))
 - Upgrade be-gateway-nginx from fedora-rpm to rocky and from version 1.19 to 1.21 ([#880](https://github.com/opendevstack/ods-quickstarters/issues/880))
+- Fix inf-terraform-agent bundler complaining about /tmp permissions ([]())
 
 ## [4.1] - 2022-11-17
 

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -145,7 +145,8 @@ RUN dnf install -y https://github.com/mozilla/sops/releases/download/v${SOPS_VER
     && tar xzf /tmp/age.tar.gz -C /usr/local/bin \
     && rm -f /tmp/age.tar.gz
 
-RUN chown -R 1001:0 $HOME \
+RUN chmod +t /tmp \
+    && chown -R 1001:0 $HOME \
     && chmod -R g+rw $HOME \
     && mkdir -p $GEM_HOME \
     && chmod 2770 $GEM_HOME


### PR DESCRIPTION
Fix permissions in /tmp to make ruby/bundler happy when installing Gems.
Bundler expects +t on /tmp.
