### PR TITLE
drop always-auth config from nodejs18 agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Removal of Centos agents ([#1209](https://github.com/opendevstack/ods-core/issues/1209))
 - Fix oauth-proxy sidecar image ([#862](https://github.com/opendevstack/ods-quickstarters/issues/862))
 - Upgrade be-gateway-nginx from fedora-rpm to rocky and from version 1.19 to 1.21 ([#880](https://github.com/opendevstack/ods-quickstarters/issues/880))
+- Fix nodejs 18 build by removing option always-auth ([#905](https://github.com/opendevstack/ods-quickstarters/issues/905))
 
 ## [4.1] - 2022-11-17
 

--- a/common/jenkins-agents/nodejs18/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/nodejs18/docker/Dockerfile.ubi8
@@ -45,7 +45,6 @@ RUN yum repolist \
     && yum clean all -y
 
 RUN npm config set registry=$nexusUrl/repository/npmjs/ && \
-    npm config set always-auth=true && \
     npm config set _auth=$(echo -n $nexusAuth | base64) && \
     npm config set email=no-reply@opendevstack.org && \
     npm config set ca=null && \


### PR DESCRIPTION
drop always-auth config from nodejs18 agent (option was neither used (in-code) nor properly documented according to changelog.

Closes #905
Fixes #905

