### PR TITLE
removed the configuration part related to protractor - master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Upgrade be-gateway-nginx from fedora-rpm to rocky and from version 1.19 to 1.21 ([#880](https://github.com/opendevstack/ods-quickstarters/issues/880))
 - Fix inf-terraform-agent bundler complaining about /tmp permissions ([#903](https://github.com/opendevstack/ods-quickstarters/pull/903))
 - Fix nodejs 18 build by removing option always-auth ([#905](https://github.com/opendevstack/ods-quickstarters/issues/905))
+- Removed protractor-related configuration from `ini.sh` in Ionic quickstarter ([#885](https://github.com/opendevstack/ods-quickstarters/issues/885))
 
 ## [4.1] - 2022-11-17
 

--- a/docs/modules/quickstarters/pages/fe-ionic.adoc
+++ b/docs/modules/quickstarters/pages/fe-ionic.adoc
@@ -19,7 +19,6 @@ The files are generated using https://ionicframework.com/docs/cli/[Ionic CLI].
 │   └── nginx.vh.default.conf.nginx
 ├── e2e
 │   ├── test.e2e-specs.ts
-│   ├── protractor.conf.js
 │   └── tsconfig.json
 ├── src
 │   ├── app

--- a/fe-ionic/init.sh
+++ b/fe-ionic/init.sh
@@ -74,20 +74,5 @@ sed -i "s|\s*reporters: \['progress', 'kjhtml'\],|    $UNIT_XML_CONFIG|" ./karma
 echo "configure coverage reporter in karma.conf.js"
 sed -i "s|{ type: 'text-summary' }|{ type: 'lcovonly' },\n        { type: 'text-summary' }|" ./karma.conf.js
 
-echo "configure headless chrome in protractor.conf.js"
-read -r -d "" PROTRACTOR_CHROME_CONFIG << EOM || true
-    browserName: 'chrome',\\
-    chromeOptions: {\\
-      args: \[\\
-        'headless',\\
-        'no-sandbox',\\
-        'disable-web-security',\\
-        '--disable-gpu',\\
-        '--window-size=1024,768'\\
-      \]\\
-    }
-EOM
-sed -i "s|\s*browserName: 'chrome'|    $PROTRACTOR_CHROME_CONFIG|" ./e2e/protractor.conf.js
-
 echo "copy files from quickstart to generated project"
 cp -rv $SCRIPT_DIR/files/. .


### PR DESCRIPTION
Code in init.sh related to protractor setup has been removed as protractor is not used anymore in Ionic.

Closes #885 
Fixes #885 

@bljubisic @cschweikert I created the PR for master branch as it is the one we use for the integration of features and bugfixes
