### PR TITLE
Scala quickstarter and agent maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Upgrade packages in Angular and TypeScript quickstarters, fix nodejs18 agent error with auth in npm9 ([#885](https://github.com/opendevstack/ods-quickstarters/issues/885))
 - Update Go quickstarter to Go 1.20 and align version of golangci-lint and go-junit-report ([#877](https://github.com/opendevstack/ods-quickstarters/issues/877))
 - Fix mismatch on java versions in base agent and jdk agent ([#916](https://github.com/opendevstack/ods-quickstarters/pull/916))
+- Scala maintenance ([#879](https://github.com/opendevstack/ods-quickstarters/issues/879))
 
 ### Modified
 

--- a/be-scala-play/Jenkinsfile.template
+++ b/be-scala-play/Jenkinsfile.template
@@ -22,7 +22,7 @@ odsComponentPipeline(
 def stageBuild(def context) {
   stage('Build and Unit Test') {
     withEnv(["TAGVERSION=${context.tagversion}"]){
-      sh "sbt clean scalafmtSbtCheck scalafmtCheckAll coverage test coverageReport copyDockerFiles"
+      sh "sbt clean scalafmtSbtCheck scalafmtCheckAll coverage test coverageOff coverageReport copyDockerFiles"
     }
   }
 }

--- a/be-scala-play/be-scala-play.g8/project/build.properties
+++ b/be-scala-play/be-scala-play.g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.7
+sbt.version=1.8.2

--- a/be-scala-play/be-scala-play.g8/src/main/g8/build.sbt
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(PlayKeys.playDefaultPort := 8080)
 
-scalaVersion := "2.13.2"
+scalaVersion := "2.13.10"
 
 credentials += Credentials(Path.userHome / ".sbt" / ".credentials")
 

--- a/be-scala-play/files/docker/Dockerfile
+++ b/be-scala-play/files/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk8:ubi-minimal-jre
+FROM adoptopenjdk/openjdk11:ubi-minimal-jre
 
 WORKDIR /app
 COPY lib/* /app/lib/

--- a/be-scala-play/files/docker/Dockerfile
+++ b/be-scala-play/files/docker/Dockerfile
@@ -6,5 +6,5 @@ COPY conf /app/conf/
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-Duser.dir=/app", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-cp", "conf/:lib/*"]
+ENTRYPOINT ["java", "-Duser.dir=/app", "-XX:+UnlockExperimentalVMOptions", "-cp", "conf/:lib/*"]
 CMD ["play.core.server.ProdServerStart"]

--- a/common/jenkins-agents/scala/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/scala/docker/Dockerfile.ubi8
@@ -13,14 +13,19 @@ RUN yum install -y java-11-openjdk-devel && \
     alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java && \
     alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac && \
     java -version && \
-    javac -version
+    javac -version && \
+## Needed in case base and scala agents has a mismatch in java versions
+    rm -fv /etc/profile.d/set-default-java.sh && \
+    echo "export JAVA_HOME=/usr/lib/jvm/${exactVersion}" >> /etc/profile.d/set-default-java.sh && \
+    echo "export USE_JAVA_VERSION=java-11" >> /etc/profile.d/set-default-java.sh && \
+    chmod +x /etc/profile.d/set-default-java.sh
 ENV JAVA_HOME=/usr/lib/jvm/jre
 
 # Container support is now integrated in Java 11, the +UseCGroupMemoryLimitForHeap option has been pruned
 ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true"
 
 # Install sbt
-ENV SBT_VERSION=1.5.4
+ENV SBT_VERSION=1.8.2
 ENV SBT_CREDENTIALS="$HOME/.sbt/.credentials"
 RUN rm -f /etc/yum.repos.d/bintray-rpm.repo && \
     curl -L https://www.scala-sbt.org/sbt-rpm.repo > sbt-rpm.repo && \


### PR DESCRIPTION
**Agent**
Update sbt to version 1.8.2 and add recent fix for java version mismatch (see #916 )

**Quickstarter**
Update sbt to vesion 1.8.2 and scala to version 2.13.10.
Update base image to use java 11.

Test:

- [x] Build new agent successfully.
- [x] Provision and build quickstarter with new agent.
- [ ] Build old version of the quickstarter with new agent.

Closes #879 for master
