### PR TITLE
update scala agent and be-scala-play quickstarter

### DIFF
--- a/be-scala-play/Jenkinsfile.template
+++ b/be-scala-play/Jenkinsfile.template
@@ -22,7 +22,7 @@ odsComponentPipeline(
 def stageBuild(def context) {
   stage('Build and Unit Test') {
     withEnv(["TAGVERSION=${context.tagversion}"]){
-      sh "sbt clean scalafmtSbtCheck scalafmtCheckAll coverage test coverageReport copyDockerFiles"
+      sh "sbt -v clean scalafmtSbtCheck scalafmtCheckAll coverage test coverageReport coverageOff compile:clean copyDockerFiles"
     }
   }
 }

--- a/be-scala-play/be-scala-play.g8/src/main/g8/.gitignore
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/.gitignore
@@ -1,8 +1,11 @@
 logs
 target
+/.bsp
 /.idea
 /.idea_modules
 /.classpath
 /.project
 /.settings
 /RUNNING_PID
+docker/conf
+docker/lib

--- a/be-scala-play/be-scala-play.g8/src/main/g8/.scalafmt.conf
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/.scalafmt.conf
@@ -1,3 +1,4 @@
-version = 2.3.0
-align = more
+version = 3.5.9
+runner.dialect = scala213source3
+align.preset = more
 maxColumn = 100

--- a/be-scala-play/be-scala-play.g8/src/main/g8/.sdkmanrc
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=22.2.r11-grl

--- a/be-scala-play/be-scala-play.g8/src/main/g8/app/controllers/HomeController.scala
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/app/controllers/HomeController.scala
@@ -4,20 +4,16 @@ import javax.inject._
 import play.api._
 import play.api.mvc._
 
-/**
-  * This controller creates an `Action` to handle HTTP requests to the
-  * application's home page.
+/** This controller creates an `Action` to handle HTTP requests to the application's home page.
   */
 @Singleton
 class HomeController @Inject() (val controllerComponents: ControllerComponents)
     extends BaseController {
 
-  /**
-    * Create an Action to render an HTML page.
+  /** Create an Action to render an HTML page.
     *
-    * The configuration in the `routes` file means that this method
-    * will be called when the application receives a `GET` request with
-    * a path of `/`.
+    * The configuration in the `routes` file means that this method will be called when the
+    * application receives a `GET` request with a path of `/`.
     */
   def index() = Action { implicit request: Request[AnyContent] =>
     Ok(views.html.index())

--- a/be-scala-play/be-scala-play.g8/src/main/g8/app/views/main.scala.html
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/app/views/main.scala.html
@@ -1,9 +1,9 @@
 @*
- * This template is called from the `index` template. This template
- * handles the rendering of the page header and body tags. It takes
- * two arguments, a `String` for the title of the page and an `Html`
- * object to insert into the body of the page.
- *@
+* This template is called from the `index` template. This template
+* handles the rendering of the page header and body tags. It takes
+* two arguments, a `String` for the title of the page and an `Html`
+* object to insert into the body of the page.
+*@
 @(title: String)(content: Html)
 
 <!DOCTYPE html>
@@ -17,9 +17,9 @@
     </head>
     <body>
         @* And here's where we render the `Html` object containing
-         * the page content. *@
+        * the page content. *@
         @content
 
-      <script src="@routes.Assets.versioned("javascripts/main.js")" type="text/javascript"></script>
+        <script src="@routes.Assets.versioned("javascripts/main.js")" type="text/javascript"></script>
     </body>
 </html>

--- a/be-scala-play/be-scala-play.g8/src/main/g8/build.sbt
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/build.sbt
@@ -1,4 +1,4 @@
-name := """$name$"""
+name         := """$name$"""
 organization := "$organization$"
 
 version := "1.0-SNAPSHOT"
@@ -7,13 +7,17 @@ lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(PlayKeys.playDefaultPort := 8080)
 
-scalaVersion := "2.13.2"
+scalaVersion := "2.13.10"
 
 credentials += Credentials(Path.userHome / ".sbt" / ".credentials")
 
+// this fixes the problem with different versions of scala-xml in twirl and the scoverage sbt plugin :F
+libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+
 val compileDependencies = Seq(
   guice,
-  "net.logstash.logback" % "logstash-logback-encoder" % "6.3"
+  "com.fasterxml.jackson.module" %% "jackson-module-scala"     % "2.13.4",
+  "net.logstash.logback"          % "logstash-logback-encoder" % "7.2"
 )
 
 val testDependencies = Seq(
@@ -33,7 +37,7 @@ libraryDependencies ++= compileDependencies ++ testDependencies
 val copyDockerFiles =
   taskKey[Unit]("copy files to the docker dir used by ods to build the docker image")
 val cleanupDockerFiles = taskKey[Unit]("delete copied docker files from docker dir")
-val dockerDir          = settingKey[File]("docker dir that will be used by ods to build the docker image")
+val dockerDir = settingKey[File]("docker dir that will be used by ods to build the docker image")
 dockerDir := baseDirectory.value / "docker"
 
 copyDockerFiles := {

--- a/be-scala-play/be-scala-play.g8/src/main/g8/conf/logback.xml
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/conf/logback.xml
@@ -1,11 +1,5 @@
-<!--
- for more information on logging see:
- https://www.playframework.com/documentation/2.8.x/ScalaLogging
- https://www.playframework.com/documentation/latest/SettingsLogger
--->
+<!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
 <configuration>
-
-<!--  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />-->
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="net.logstash.logback.encoder.LogstashEncoder" />

--- a/be-scala-play/be-scala-play.g8/src/main/g8/conf/routes
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/conf/routes
@@ -4,7 +4,7 @@
 # ~~~~
 
 # An example controller showing a sample home page
-GET     /                           controllers.HomeController.index
+GET     /                           controllers.HomeController.index()
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)

--- a/be-scala-play/be-scala-play.g8/src/main/g8/project/build.properties
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.7.2

--- a/be-scala-play/be-scala-play.g8/src/main/g8/project/plugins.sbt
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/project/plugins.sbt
@@ -1,6 +1,8 @@
 credentials += Credentials(Path.userHome / ".sbt" / ".credentials")
 
-addSbtPlugin("com.typesafe.play"        % "sbt-plugin"          % "2.8.2")
-addSbtPlugin("org.scalameta"            % "sbt-scalafmt"        % "2.4.0")
-addSbtPlugin("org.scoverage"            % "sbt-scoverage"       % "1.6.1")
-addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8-scaffold" % "0.11.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"    % "2.8.18")
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt"  % "2.4.6")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "2.0.6")
+
+// this fixes the problem with different versions of scala-xml in twirl and the scoverage sbt plugin :F
+libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/be-scala-play/be-scala-play.g8/src/main/g8/test/controllers/HomeControllerSpec.scala
+++ b/be-scala-play/be-scala-play.g8/src/main/g8/test/controllers/HomeControllerSpec.scala
@@ -5,11 +5,10 @@ import org.scalatestplus.play.guice._
 import play.api.test._
 import play.api.test.Helpers._
 
-/**
-  * Add your spec here.
-  * You can mock out a whole application including requests, plugins etc.
+/** Add your spec here. You can mock out a whole application including requests, plugins etc.
   *
-  * For more information, see https://www.playframework.com/documentation/latest/ScalaTestingWithScalaTest
+  * For more information, see
+  * https://www.playframework.com/documentation/latest/ScalaTestingWithScalaTest
   */
 class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting {
 

--- a/be-scala-play/files/docker/Dockerfile
+++ b/be-scala-play/files/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk8:ubi-minimal-jre
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.14
 
 WORKDIR /app
 COPY lib/* /app/lib/
@@ -6,5 +6,5 @@ COPY conf /app/conf/
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-Duser.dir=/app", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-cp", "conf/:lib/*"]
+ENTRYPOINT ["java", "-Duser.dir=/app", "-XX:+UnlockExperimentalVMOptions", "-cp", "conf/:lib/*"]
 CMD ["play.core.server.ProdServerStart"]

--- a/common/jenkins-agents/scala/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/scala/docker/Dockerfile.ubi8
@@ -1,4 +1,4 @@
-FROM opendevstackorg/ods-jenkins-agent-base-ubi8
+FROM opendevstackorg/ods-jenkins-agent-base-ubi8:latest
 
 LABEL maintainer="Jan Frank <jan.frank@boehringer-ingelheim.com>"
 
@@ -19,8 +19,9 @@ ENV JAVA_HOME=/usr/lib/jvm/jre
 # Container support is now integrated in Java 11, the +UseCGroupMemoryLimitForHeap option has been pruned
 ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true"
 
+
 # Install sbt
-ENV SBT_VERSION=1.5.4
+ENV SBT_VERSION=1.8.2
 ENV SBT_CREDENTIALS="$HOME/.sbt/.credentials"
 RUN rm -f /etc/yum.repos.d/bintray-rpm.repo && \
     curl -L https://www.scala-sbt.org/sbt-rpm.repo > sbt-rpm.repo && \
@@ -46,7 +47,6 @@ RUN cat $HOME/.sbt/repositories | sed -e "s|NEXUS_URL|$nexusUrl|g" > $HOME/.sbt/
     cd /tmp && \
     /tmp/set_sbt_proxy.sh && \
     if [ ! -f "/usr/bin/sbt" ]; then echo "sbt path /usr/bin/sbt could not be found"; exit 1 ; fi
-
 
 RUN chgrp -R 0 $HOME && \
     chmod -R g=u $HOME


### PR DESCRIPTION
**Agent**
Update sbt to version 1.8.2 and add recent fix for java version mismatch (see #916 )

**Quickstarter**
Update sbt to vesion 1.8.2 and scala to version 2.13.10.
Update base image to use java 11.

Test:

- [ ] Build new agent successfully.
- [ ] Provision and build quickstarter with new agent.
- [ ] Build old version of the quickstarter with new agent.

Closes #879 for master
