### PR TITLE
inf-terraform-[aws|azure], bump inspec-aws & inspec-azure, fix testing yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Update of Maven agent, Java and Spock/Geb quickstarter ([#878](https://github.com/opendevstack/ods-quickstarters/issues/878))
 - inf-terraform-[aws|azure], add new jenkins-agent-terraform-2306 with updated tools (ruby 3.2.2, python 3.11, etc.) and dependencies, add tflint, mark other jenkins-agent-terraform as deprecated([#914](https://github.com/opendevstack/ods-quickstarters/issues/914))
 - Update of Python agent, Python, Streamlit and Jupyter quickstarters ([#902](https://github.com/opendevstack/ods-quickstarters/issues/902))
-- inf-terraform-[aws|azure], bump inspec-aws (v1.83.60) & inspec-azure (v1.118.41) library versions, drop use of symbolized keys in helper yaml files ([#926](https://github.com/opendevstack/ods-quickstarters/issues/926))
+- inf-terraform-[aws|azure], bump inspec-aws (v1.83.60) & inspec-azure (v1.118.41) library versions, drop use of symbolized keys in helper yaml files ([#927](https://github.com/opendevstack/ods-quickstarters/issues/927))
 
 ## [4.1] - 2022-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Update of Maven agent, Java and Spock/Geb quickstarter ([#878](https://github.com/opendevstack/ods-quickstarters/issues/878))
 - inf-terraform-[aws|azure], add new jenkins-agent-terraform-2306 with updated tools (ruby 3.2.2, python 3.11, etc.) and dependencies, add tflint, mark other jenkins-agent-terraform as deprecated([#914](https://github.com/opendevstack/ods-quickstarters/issues/914))
 - Update of Python agent, Python, Streamlit and Jupyter quickstarters ([#902](https://github.com/opendevstack/ods-quickstarters/issues/902))
+- inf-terraform-[aws|azure], bump inspec-aws (v1.83.60) & inspec-azure (v1.118.41) library versions, drop use of symbolized keys in helper yaml files ([#926](https://github.com/opendevstack/ods-quickstarters/issues/926))
 
 ## [4.1] - 2022-11-17
 

--- a/inf-terraform-aws/files/Makefile
+++ b/inf-terraform-aws/files/Makefile
@@ -140,7 +140,7 @@ install-test-deps: install-ruby-gems install-python-env
 # run cinc-auditor without use of kitchen-terraform and create yaml for mapping terraform outputs to inspec inputs.
 cinc-auditor-test:
 	sh ./lib/scripts/createstackfixtureoutputs2yml.sh
-	bundle exec cinc-auditor exec test/integration/default --no-create-lockfile --no-distinct-exit --input-file ./test/integration/$$profile/files/inputs-from-tfo-stack.yml --target aws://
+	bundle exec cinc-auditor exec test/integration/default --no-create-lockfile --no-distinct-exit --input-file ./test/integration/default/files/inputs-from-tfo-stack.yml --target aws://
 
 .PHONY: clean
 # Reset Working directory (take care if something has deployed upfront)

--- a/inf-terraform-aws/files/lib/scripts/createstackfixtureoutputs2yml.sh
+++ b/inf-terraform-aws/files/lib/scripts/createstackfixtureoutputs2yml.sh
@@ -29,9 +29,9 @@ cd ${CWD}/test/fixtures/default
 terraform output -json > "${TOJFILE}"
 
 # Convert terraform json outputs to yaml.
-# Use symbolize_names for keys ("id" -> :id)
-# Symbolize_names is required, as kitchen-terraform outputs are created as inspec inputs using this type for keys.
+# Do not use symbolize_names for keys ("id" -> :id).
+# Symbolize_names is no longer required, as kitchen-terraform outputs are created as inspec inputs using this type for keys.
 jq 'with_entries(.value |= .value)|with_entries(.key = "output_" + .key)' "${TOJFILE}" | \
-  ruby -ryaml -rjson -e 'puts YAML.dump(JSON.parse(STDIN.read, :symbolize_names => true))' > "${TOYFILE}"
+  ruby -ryaml -rjson -e 'puts YAML.dump(JSON.parse(STDIN.read, :symbolize_names => false))' > "${TOYFILE}"
 
 popd

--- a/inf-terraform-aws/files/lib/scripts/createstackoutputs2yml.sh
+++ b/inf-terraform-aws/files/lib/scripts/createstackoutputs2yml.sh
@@ -28,9 +28,9 @@ pushd .
 terraform output -json > "${TOJFILE}"
 
 # Convert terraform json outputs to yaml.
-# Use symbolize_names for keys ("id" -> :id)
-# Symbolize_names is required, as kitchen-terraform outputs are created as inspec inputs using this type for keys.
+# Do not use symbolize_names for keys ("id" -> :id).
+# Symbolize_names is no longer required, as kitchen-terraform outputs are created as inspec inputs using this type for keys.
 jq 'with_entries(.value |= .value)|with_entries(.key = "output_" + .key)' "${TOJFILE}" | \
-  ruby -ryaml -rjson -e 'puts YAML.dump(JSON.parse(STDIN.read, :symbolize_names => true))' > "${TOYFILE}"
+  ruby -ryaml -rjson -e 'puts YAML.dump(JSON.parse(STDIN.read, :symbolize_names => false))' > "${TOYFILE}"
 
 popd

--- a/inf-terraform-aws/files/test/integration/default/inspec.yml
+++ b/inf-terraform-aws/files/test/integration/default/inspec.yml
@@ -7,4 +7,4 @@ supports:
 depends:
   - name: inspec-aws
     git: https://github.com/inspec/inspec-aws
-    tag: v1.80.0
+    tag: v1.83.60

--- a/inf-terraform-aws/files/test/integration/default/inspec.yml.tmpl
+++ b/inf-terraform-aws/files/test/integration/default/inspec.yml.tmpl
@@ -5,4 +5,4 @@ supports:
 depends:
   - name: inspec-aws
     git: https://github.com/inspec/inspec-aws
-    tag: v1.80.0
+    tag: v1.83.60

--- a/inf-terraform-azure/files/README.md
+++ b/inf-terraform-azure/files/README.md
@@ -50,7 +50,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_is_test"></a> [is\_test](#input\_is\_test) | Whether whether it is part of a test execution or not. Defaults to false. | `bool` | `false` | no |
 | <a name="input_meta_environment"></a> [meta\_environment](#input\_meta\_environment) | The type of the environment. Can be any of DEVELOPMENT, EVALUATION, PRODUCTIVE, QUALITYASSURANCE, TRAINING, VALIDATION. | `string` | `"DEVELOPMENT"` | no |
-| <a name="input_name"></a> [name](#input\_name) | The name of the stack. | `string` | `"stack-azure-quickstarter-delete-me"` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the stack. | `string` | `"stack-azure-quickstarter"` | no |
 
 ## Outputs
 

--- a/inf-terraform-azure/files/lib/scripts/createstackfixtureoutputs2yml.sh
+++ b/inf-terraform-azure/files/lib/scripts/createstackfixtureoutputs2yml.sh
@@ -29,9 +29,9 @@ cd ${CWD}/test/fixtures/default
 terraform output -json > "${TOJFILE}"
 
 # Convert terraform json outputs to yaml.
-# Use symbolize_names for keys ("id" -> :id)
-# Symbolize_names is required, as kitchen-terraform outputs are created as inspec inputs using this type for keys.
+# Do not use symbolize_names for keys ("id" -> :id).
+# Symbolize_names is no longer required, as kitchen-terraform outputs are created as inspec inputs using this type for keys.
 jq 'with_entries(.value |= .value)|with_entries(.key = "output_" + .key)' "${TOJFILE}" | \
-  ruby -ryaml -rjson -e 'puts YAML.dump(JSON.parse(STDIN.read, :symbolize_names => true))' > "${TOYFILE}"
+  ruby -ryaml -rjson -e 'puts YAML.dump(JSON.parse(STDIN.read, :symbolize_names => false))' > "${TOYFILE}"
 
 popd

--- a/inf-terraform-azure/files/lib/scripts/createstackoutputs2yml.sh
+++ b/inf-terraform-azure/files/lib/scripts/createstackoutputs2yml.sh
@@ -28,9 +28,9 @@ pushd .
 terraform output -json > "${TOJFILE}"
 
 # Convert terraform json outputs to yaml.
-# Use symbolize_names for keys ("id" -> :id)
-# Symbolize_names is required, as kitchen-terraform outputs are created as inspec inputs using this type for keys.
+# Do not use symbolize_names for keys ("id" -> :id).
+# Symbolize_names is no longer required, as kitchen-terraform outputs are created as inspec inputs using this type for keys.
 jq 'with_entries(.value |= .value)|with_entries(.key = "output_" + .key)' "${TOJFILE}" | \
-  ruby -ryaml -rjson -e 'puts YAML.dump(JSON.parse(STDIN.read, :symbolize_names => true))' > "${TOYFILE}"
+  ruby -ryaml -rjson -e 'puts YAML.dump(JSON.parse(STDIN.read, :symbolize_names => false))' > "${TOYFILE}"
 
 popd

--- a/inf-terraform-azure/files/test/integration/default/inspec.yml
+++ b/inf-terraform-azure/files/test/integration/default/inspec.yml
@@ -7,4 +7,4 @@ supports:
 depends:
   - name: inspec-azure
     git: https://github.com/inspec/inspec-azure
-    tag: v1.86.0
+    tag: v1.118.41

--- a/inf-terraform-azure/files/test/integration/default/inspec.yml.tmpl
+++ b/inf-terraform-azure/files/test/integration/default/inspec.yml.tmpl
@@ -5,4 +5,4 @@ supports:
 depends:
   - name: inspec-azure
     git: https://github.com/inspec/inspec-azure
-    tag: v1.86.0
+    tag: v1.118.41

--- a/inf-terraform-azure/files/variables.tf
+++ b/inf-terraform-azure/files/variables.tf
@@ -23,7 +23,7 @@
 variable "name" {
   description = "The name of the stack."
   type        = string
-  default     = "stack-azure-quickstarter-delete-me"
+  default     = "stack-azure-quickstarter"
 }
 
 variable "is_test" {


### PR DESCRIPTION
Description:

inf-terraform-[aws|azure], bump inspec-aws (v1.83.60) & inspec-azure (v1.118.41) library versions, drop use of symbolized keys in helper yaml files

Tasks: 
- [ ] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
