### PR TITLE
inf-terraform-aws:  switch from shared statefile location to dedicated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,8 @@
 - Fix imagePullPolicy issue when verifying the image ([#874](https://github.com/opendevstack/ods-quickstarters/issues/874))
 - Set default rollout strategy to recreate ([#926](https://github.com/opendevstack/ods-quickstarters/issues/926))
 - Add binutils to jdk agent ([929](https://github.com/opendevstack/ods-quickstarters/issues/929))
-<<<<<<< HEAD
-- inf-terraform-[aws], switch from shared statefile location to dedicated bucket ([#900](https://github.com/opendevstack/ods-quickstarters/issues/900))
-=======
 - Change golden tests to be able to execute them in other namespaces ([933](https://github.com/opendevstack/ods-quickstarters/pull/933))
->>>>>>> master
+- inf-terraform-[aws], switch from shared statefile location to dedicated bucket ([#900](https://github.com/opendevstack/ods-quickstarters/issues/900))
 
 ## [4.1] - 2022-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix imagePullPolicy issue when verifying the image ([#874](https://github.com/opendevstack/ods-quickstarters/issues/874))
 - Set default rollout strategy to recreate ([#926](https://github.com/opendevstack/ods-quickstarters/issues/926))
 - Add binutils to jdk agent ([929](https://github.com/opendevstack/ods-quickstarters/issues/929))
+- inf-terraform-[aws], switch from shared statefile location to dedicated bucket ([#900](https://github.com/opendevstack/ods-quickstarters/issues/900))
 
 ## [4.1] - 2022-11-17
 

--- a/inf-terraform-aws/files/.pre-commit-config.yaml
+++ b/inf-terraform-aws/files/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
   - id: terraform_fmt
 
 - repo: https://github.com/nichtraunzer/ods-pre-commit-hooks
-  rev: v0.4.1
+  rev: v0.4.2
   hooks:
   - id: terraformcreatei2o
     files: (\.tf)$

--- a/inf-terraform-aws/files/Makefile
+++ b/inf-terraform-aws/files/Makefile
@@ -64,8 +64,6 @@ test: install-test-deps
 		./.venv/bin/python3 ./.venv/bin/hcl2tojson test/fixtures/$$fdir/main.tf  test/integration/$$fdir/files/main.json; \
 	done \
 
-	exit 0
-
 	# See https://github.com/test-kitchen/test-kitchen/issues/1436 for why a simple `bundle exec kitchen test` is not an option.
 	for suite in $$(bundle exec kitchen list --bare); do \
 		bundle exec kitchen verify $$suite || { bundle exec kitchen destroy $$suite; exit 1; }; \
@@ -156,7 +154,7 @@ install-test-deps: install-ruby-gems install-python-env
 # run cinc-auditor without use of kitchen-terraform and create yaml for mapping terraform outputs to inspec inputs.
 cinc-auditor-test:
 	sh ./lib/scripts/createstackfixtureoutputs2yml.sh
-	bundle exec cinc-auditor exec test/integration/default --no-create-lockfile --no-distinct-exit --input-file ./test/integration/$$profile/files/inputs-from-tfo-stack.yml --target aws://
+	bundle exec cinc-auditor exec test/integration/default --no-create-lockfile --no-distinct-exit --input-file ./test/integration/default/files/inputs-from-tfo-stack.yml --target aws://
 
 .PHONY: clean
 # Reset Working directory (take care if something has deployed upfront)

--- a/inf-terraform-aws/files/Makefile
+++ b/inf-terraform-aws/files/Makefile
@@ -15,6 +15,15 @@ TF_WORKSPACE             = default
 # tfenv hack
 DEBUG                    := 0
 
+# Statefile Parameters
+ACCOUNT_ID               := $(shell aws sts get-caller-identity --query 'Account' --output text)
+TF_BACKEND_S3KEY_MOD     := $(shell echo "$(TF_BACKEND_S3KEY)" | sed "s/\//-/g")
+TF_BACKEND_S3KEY_MOD     := $(shell echo "$(TF_BACKEND_S3KEY_MOD)" | sed "s/-/\//")
+
+TFSTATE_BUCKET           := $(ACCOUNT_ID)-terraform-state-bucket
+TFSTATE_KEY              := $(TF_BACKEND_S3KEY_MOD)-terraform-state
+TFSTATE_TABLE            := $(ACCOUNT_ID)-terraform-state-lock-table
+
 
 .PHONY: default
 default: test
@@ -54,6 +63,8 @@ test: install-test-deps
 		mkdir -p test/integration/$$fdir/files ; \
 		./.venv/bin/python3 ./.venv/bin/hcl2tojson test/fixtures/$$fdir/main.tf  test/integration/$$fdir/files/main.json; \
 	done \
+
+	exit 0
 
 	# See https://github.com/test-kitchen/test-kitchen/issues/1436 for why a simple `bundle exec kitchen test` is not an option.
 	for suite in $$(bundle exec kitchen list --bare); do \
@@ -130,7 +141,12 @@ install-python-env:
 .PHONY: init-terraform
 # Install Terraform workspace.
 init-terraform:
-	echo 1 | terraform init -backend=true -force-copy -input=false -backend-config="workspace_key_prefix=$(TF_BACKEND_PREFIX)" -backend-config="key=$(TF_BACKEND_S3KEY)/terraform.tfstate"
+
+	@echo "Bucket: ${TFSTATE_BUCKET}"
+	@echo "Key   : ${TFSTATE_KEY}"
+	@echo "Table : ${TFSTATE_TABLE}"
+
+	echo 1 | terraform init -backend-config="bucket=$(TFSTATE_BUCKET)" -backend-config="key=$(TFSTATE_KEY)" -backend-config="dynamodb_table=$(TFSTATE_TABLE)" -force-copy -input=false
 
 .PHONY: install-test-deps
 # Install testing dependencies.
@@ -140,7 +156,7 @@ install-test-deps: install-ruby-gems install-python-env
 # run cinc-auditor without use of kitchen-terraform and create yaml for mapping terraform outputs to inspec inputs.
 cinc-auditor-test:
 	sh ./lib/scripts/createstackfixtureoutputs2yml.sh
-	bundle exec cinc-auditor exec test/integration/default --no-create-lockfile --no-distinct-exit --input-file ./test/integration/default/files/inputs-from-tfo-stack.yml --target aws://
+	bundle exec cinc-auditor exec test/integration/default --no-create-lockfile --no-distinct-exit --input-file ./test/integration/$$profile/files/inputs-from-tfo-stack.yml --target aws://
 
 .PHONY: clean
 # Reset Working directory (take care if something has deployed upfront)

--- a/inf-terraform-aws/files/README.md
+++ b/inf-terraform-aws/files/README.md
@@ -24,13 +24,15 @@ The behavior of a stack is determined by its purpose and the set of input parame
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | n/a |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.4.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
-| <a name="provider_time"></a> [time](#provider\_time) | n/a |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.9.1 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | git::https://bitbucket.biscrum.com/scm/infiaas/blueprint-aws-s3.git | v6.0.0 |
 
 ## Resources
 
@@ -40,6 +42,7 @@ No modules.
 | [local_file.terraform-data](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [random_id.id](https://registry.terraform.io/providers/hashicorp/random/3.5.1/docs/resources/id) | resource |
 | [time_static.deployment](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static) | resource |
+| [aws_iam_policy_document.read_and_write_bucket](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -48,6 +51,9 @@ No modules.
 | <a name="input_data_bucket_name"></a> [data\_bucket\_name](#input\_data\_bucket\_name) | The name of the S3 data bucket. | `string` | `"quickstarter"` | no |
 | <a name="input_meta_environment"></a> [meta\_environment](#input\_meta\_environment) | The type of the environment. Can be any of DEVELOPMENT, EVALUATION, PRODUCTIVE, QUALITYASSURANCE, TRAINING, VALIDATION. | `string` | `"DEVELOPMENT"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the stack. | `string` | `"stack-aws-quickstarter"` | no |
+| <a name="input_s3_bucket_versioning"></a> [s3\_bucket\_versioning](#input\_s3\_bucket\_versioning) | Setup the bucket versioning to be Enabled, Suspended, or Disabled. | `string` | `"Enabled"` | no |
+| <a name="input_s3_force_destroy"></a> [s3\_force\_destroy](#input\_s3\_force\_destroy) | Defines if all objects in the bucket shall be destroyed so that the bucket can be deleted, or not (true for testing). | `bool` | `true` | no |
+| <a name="input_s3_name"></a> [s3\_name](#input\_s3\_name) | The name of the S3 bucket. | `string` | `"chooseanameforthebucket"` | no |
 
 ## Outputs
 
@@ -55,7 +61,10 @@ No modules.
 |------|-------------|
 | <a name="output_inputs2outputs"></a> [inputs2outputs](#output\_inputs2outputs) | all inputs passed to outputs |
 | <a name="output_meta_environment"></a> [meta\_environment](#output\_meta\_environment) | The type of the environment. |
+| <a name="output_module_blueprint_aws_s3"></a> [module\_blueprint\_aws\_s3](#output\_module\_blueprint\_aws\_s3) | n/a |
 | <a name="output_name"></a> [name](#output\_name) | The name of the stack. |
+| <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The ARN of the s3 bucket. |
+| <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id) | The ID of the s3 bucket. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## How to test this Stack?
@@ -79,7 +88,7 @@ Extending a stack basically involves adding more blueprints whichever fit, and g
 Setting up stack development guardrails requires the following dependencies: `make`, `tee`, `ruby`, [`bundler`](https://bundler.io/), `python`, [`pre-commit`](https://pre-commit.com/) [`terraform`](https://www.terraform.io/), and [`terraform-docs`](https://github.com/segmentio/terraform-docs). Once installed, run `make install-dev-deps` to install a set of quality improving *pre-commit hooks* into your local Git repository. Upon a `git commit`, these hooks will make sure that your code is both syntactically and functionally correct and that your `README.md` contains up-to-date documentation of your stack's supported set of *inputs* and *outputs*.
 
 ## Environments
-The stack supports multiple environments (Testing/DEV/QA/PROD) within OpenDevStack. The behaviour of the stack in the environments can be controlled within the **environments** directory.
+The stack supports multiple environments (testing/DEV/QA/PROD) within OpenDevStack. The behaviour of the stack in the environments can be controlled within the **environments** directory.
 The *.yml files define the Jenkins secrets to read and are used to deploy into the right environments.
 The *.json files can override variables from **variables.tf** in case different environments request different inputs (e.g. deploy a smaller version of the stack in DEV).
 
@@ -88,9 +97,9 @@ Runing `make check-config` will do a basic verification on the stack setup and p
 
 ```
 $ make check-config
-Account "XXXXXXXXXXXX" is configured for the "dev" environment...........Passed
-There is no account configured for the "test" environment................ Warn
-There is no account configured for the "prod" environment................ Warn
+Account "XXXXXXXXXXXX" is configured for the dev environment...........Passed
+There is no account configured for the test environment................ Warn
+There is no account configured for the prod environment................ Warn
 AWS account configured using SSO.........................................Passed
   Using "YYYYYYYYYYYYYY:ZZZZZZZZ@MyOrganization.com".....................Passed
 Backend configured to "MyStateFileLocation"..............................Passed

--- a/inf-terraform-aws/files/README.md
+++ b/inf-terraform-aws/files/README.md
@@ -24,15 +24,13 @@ The behavior of a stack is determined by its purpose and the set of input parame
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.4.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | n/a |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.9.1 |
+| <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | git::https://bitbucket.biscrum.com/scm/infiaas/blueprint-aws-s3.git | v6.0.0 |
+No modules.
 
 ## Resources
 
@@ -42,7 +40,6 @@ The behavior of a stack is determined by its purpose and the set of input parame
 | [local_file.terraform-data](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [random_id.id](https://registry.terraform.io/providers/hashicorp/random/3.5.1/docs/resources/id) | resource |
 | [time_static.deployment](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static) | resource |
-| [aws_iam_policy_document.read_and_write_bucket](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -51,9 +48,6 @@ The behavior of a stack is determined by its purpose and the set of input parame
 | <a name="input_data_bucket_name"></a> [data\_bucket\_name](#input\_data\_bucket\_name) | The name of the S3 data bucket. | `string` | `"quickstarter"` | no |
 | <a name="input_meta_environment"></a> [meta\_environment](#input\_meta\_environment) | The type of the environment. Can be any of DEVELOPMENT, EVALUATION, PRODUCTIVE, QUALITYASSURANCE, TRAINING, VALIDATION. | `string` | `"DEVELOPMENT"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the stack. | `string` | `"stack-aws-quickstarter"` | no |
-| <a name="input_s3_bucket_versioning"></a> [s3\_bucket\_versioning](#input\_s3\_bucket\_versioning) | Setup the bucket versioning to be Enabled, Suspended, or Disabled. | `string` | `"Enabled"` | no |
-| <a name="input_s3_force_destroy"></a> [s3\_force\_destroy](#input\_s3\_force\_destroy) | Defines if all objects in the bucket shall be destroyed so that the bucket can be deleted, or not (true for testing). | `bool` | `true` | no |
-| <a name="input_s3_name"></a> [s3\_name](#input\_s3\_name) | The name of the S3 bucket. | `string` | `"chooseanameforthebucket"` | no |
 
 ## Outputs
 
@@ -61,10 +55,7 @@ The behavior of a stack is determined by its purpose and the set of input parame
 |------|-------------|
 | <a name="output_inputs2outputs"></a> [inputs2outputs](#output\_inputs2outputs) | all inputs passed to outputs |
 | <a name="output_meta_environment"></a> [meta\_environment](#output\_meta\_environment) | The type of the environment. |
-| <a name="output_module_blueprint_aws_s3"></a> [module\_blueprint\_aws\_s3](#output\_module\_blueprint\_aws\_s3) | n/a |
 | <a name="output_name"></a> [name](#output\_name) | The name of the stack. |
-| <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The ARN of the s3 bucket. |
-| <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id) | The ID of the s3 bucket. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## How to test this Stack?
@@ -88,7 +79,7 @@ Extending a stack basically involves adding more blueprints whichever fit, and g
 Setting up stack development guardrails requires the following dependencies: `make`, `tee`, `ruby`, [`bundler`](https://bundler.io/), `python`, [`pre-commit`](https://pre-commit.com/) [`terraform`](https://www.terraform.io/), and [`terraform-docs`](https://github.com/segmentio/terraform-docs). Once installed, run `make install-dev-deps` to install a set of quality improving *pre-commit hooks* into your local Git repository. Upon a `git commit`, these hooks will make sure that your code is both syntactically and functionally correct and that your `README.md` contains up-to-date documentation of your stack's supported set of *inputs* and *outputs*.
 
 ## Environments
-The stack supports multiple environments (testing/DEV/QA/PROD) within OpenDevStack. The behaviour of the stack in the environments can be controlled within the **environments** directory.
+The stack supports multiple environments (Testing/DEV/QA/PROD) within OpenDevStack. The behaviour of the stack in the environments can be controlled within the **environments** directory.
 The *.yml files define the Jenkins secrets to read and are used to deploy into the right environments.
 The *.json files can override variables from **variables.tf** in case different environments request different inputs (e.g. deploy a smaller version of the stack in DEV).
 
@@ -97,9 +88,9 @@ Runing `make check-config` will do a basic verification on the stack setup and p
 
 ```
 $ make check-config
-Account "XXXXXXXXXXXX" is configured for the dev environment...........Passed
-There is no account configured for the test environment................ Warn
-There is no account configured for the prod environment................ Warn
+Account "XXXXXXXXXXXX" is configured for the dev environment.............Passed
+There is no account configured for the test environment.................. Warn
+There is no account configured for the prod environment.................. Warn
 AWS account configured using SSO.........................................Passed
   Using "YYYYYYYYYYYYYY:ZZZZZZZZ@MyOrganization.com".....................Passed
 Backend configured to "MyStateFileLocation"..............................Passed

--- a/inf-terraform-aws/files/backend.tf
+++ b/inf-terraform-aws/files/backend.tf
@@ -1,7 +1,5 @@
 terraform {
   backend "s3" {
-    bucket = "<your_bucket_name>"
     region = "eu-west-1"
-    acl    = "bucket-owner-full-control"
   }
 }

--- a/inf-terraform-aws/files/lib/scripts/aws/check_conf.sh
+++ b/inf-terraform-aws/files/lib/scripts/aws/check_conf.sh
@@ -48,7 +48,7 @@ function note() {
 }
 
 function check_backend() {
-  BUCKET=$(grep "bucket =" backend.tf | awk -F '=' '{print $2}'|tr -d '"'|xargs)
+  BUCKET="$ACCOUNT-terraform-state-bucket"
   if [ -n "$BUCKET" ]; then
     if [ "$BUCKET" = "$DEFAULTBUCKET" ]; then
       nok "TF Backend is not configured. Check your backend.tf file"

--- a/inf-terraform-aws/files/test/fixtures/default/random.tf
+++ b/inf-terraform-aws/files/test/fixtures/default/random.tf
@@ -4,16 +4,3 @@ resource "random_id" "id" {
   byte_length = 4
 }
 
-resource "random_string" "passwordrds" {
-  length           = 16
-  min_lower        = 1
-  min_upper        = 1
-  number           = true
-  special          = true
-  override_special = "!#+%"
-}
-
-locals {
-  id       = random_id.id.hex
-  password = random_string.passwordrds.result
-}

--- a/inf-terraform-aws/files/test/fixtures/default/random.tf
+++ b/inf-terraform-aws/files/test/fixtures/default/random.tf
@@ -4,3 +4,6 @@ resource "random_id" "id" {
   byte_length = 4
 }
 
+locals {
+  id       = random_id.id.hex
+}

--- a/inf-terraform-aws/files/test/fixtures/default/random.tf
+++ b/inf-terraform-aws/files/test/fixtures/default/random.tf
@@ -5,5 +5,5 @@ resource "random_id" "id" {
 }
 
 locals {
-  id       = random_id.id.hex
+  id = random_id.id.hex
 }

--- a/inf-terraform-azure/files/.pre-commit-config.yaml
+++ b/inf-terraform-azure/files/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     -   id: terraform_fmt
 
 -   repo: https://github.com/nichtraunzer/ods-pre-commit-hooks
-    rev: v0.4.1
+    rev: v0.4.2
     hooks:
     -   id: terraformcreatei2o
         files: (\.tf)$


### PR DESCRIPTION
This PR enables the AWS quickstarter to store the terraform statefile inside its own account. Processing takes place in the Makefile so no change in the shared library necessary.

Closes #900 

Tasks: 
- [ ] Updated documentation in `docs/modules/...` directory
- [x] Ran tests in `<quickstarter>/testdata` directory
