### PR TITLE
Change sonar-scan.json and release manager template to use any project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix imagePullPolicy issue when verifying the image ([#874](https://github.com/opendevstack/ods-quickstarters/issues/874))
 - Set default rollout strategy to recreate ([#926](https://github.com/opendevstack/ods-quickstarters/issues/926))
 - Add binutils to jdk agent ([929](https://github.com/opendevstack/ods-quickstarters/issues/929))
+- Change golden tests to be able to execute them in other namespaces ([933](https://github.com/opendevstack/ods-quickstarters/pull/933))
 
 ## [4.1] - 2022-11-17
 

--- a/be-golang-plain/testdata/golden/sonar-scan.json
+++ b/be-golang-plain/testdata/golden/sonar-scan.json
@@ -1,13 +1,12 @@
 {
-  "key": "unitt-golang-iq-test",
-  "organization": "default-organization",
-  "name": "unitt-golang-iq-test",
+  "key": "{{.ProjectID}}-{{.ComponentID}}",
+  "name": "{{.ProjectID}}-{{.ComponentID}}",
   "isFavorite": false,
   "visibility": "public",
   "extensions": [],
   "qualityProfiles": [
     {
-      "name": "Sonar way",
+      "name": "{{.SonarQualityProfile}}",
       "language": "go",
       "deleted": false
     }
@@ -18,8 +17,8 @@
   },
   "breadcrumbs": [
     {
-      "key": "unitt-golang-iq-test",
-      "name": "unitt-golang-iq-test",
+      "key": "{{.ProjectID}}-{{.ComponentID}}",
+      "name": "{{.ProjectID}}-{{.ComponentID}}",
       "qualifier": "TRK"
     }
   ]

--- a/be-java-springboot/testdata/golden/sonar-scan.json
+++ b/be-java-springboot/testdata/golden/sonar-scan.json
@@ -1,13 +1,12 @@
 {
-  "key": "unitt-springboot",
-  "organization": "default-organization",
-  "name": "unitt-springboot",
+  "key": "{{.ProjectID}}-{{.ComponentID}}",
+  "name": "{{.ProjectID}}-{{.ComponentID}}",
   "isFavorite": false,
   "visibility": "public",
   "extensions": [],
   "qualityProfiles": [
     {
-      "name": "Sonar way",
+      "name": "{{.SonarQualityProfile}}",
       "language": "java",
       "deleted": false
     }
@@ -18,8 +17,8 @@
   },
   "breadcrumbs": [
     {
-      "key": "unitt-springboot",
-      "name": "unitt-springboot",
+      "key": "{{.ProjectID}}-{{.ComponentID}}",
+      "name": "{{.ProjectID}}-{{.ComponentID}}",
       "qualifier": "TRK"
     }
   ]

--- a/be-python-flask/testdata/golden/sonar-scan.json
+++ b/be-python-flask/testdata/golden/sonar-scan.json
@@ -1,13 +1,12 @@
 {
-  "key": "unitt-python-flask-iq-test",
-  "organization": "default-organization",
-  "name": "unitt-python-flask-iq-test",
+  "key": "{{.ProjectID}}-{{.ComponentID}}",
+  "name": "{{.ProjectID}}-{{.ComponentID}}",
   "isFavorite": false,
   "visibility": "public",
   "extensions": [],
   "qualityProfiles": [
     {
-      "name": "Sonar way",
+      "name": "{{.SonarQualityProfile}}",
       "language": "py",
       "deleted": false
     }
@@ -18,8 +17,8 @@
   },
   "breadcrumbs": [
     {
-      "key": "unitt-python-flask-iq-test",
-      "name": "unitt-python-flask-iq-test",
+      "key": "{{.ProjectID}}-{{.ComponentID}}",
+      "name": "{{.ProjectID}}-{{.ComponentID}}",
       "qualifier": "TRK"
     }
   ]

--- a/be-scala-play/testdata/golden/sonar-scan.json
+++ b/be-scala-play/testdata/golden/sonar-scan.json
@@ -1,13 +1,12 @@
 {
-  "key": "unitt-be-scala-play-test",
-  "organization": "default-organization",
-  "name": "unitt-be-scala-play-test",
+  "key": "{{.ProjectID}}-{{.ComponentID}}",
+  "name": "{{.ProjectID}}-{{.ComponentID}}",
   "isFavorite": false,
   "visibility": "public",
   "extensions": [],
   "qualityProfiles": [
     {
-      "name": "Sonar way",
+      "name": "{{.SonarQualityProfile}}",
       "language": "scala",
       "deleted": false
     }
@@ -18,8 +17,8 @@
   },
   "breadcrumbs": [
     {
-      "key": "unitt-be-scala-play-test",
-      "name": "unitt-be-scala-play-test",
+      "key": "{{.ProjectID}}-{{.ComponentID}}",
+      "name": "{{.ProjectID}}-{{.ComponentID}}",
       "qualifier": "TRK"
     }
   ]

--- a/be-typescript-express/testdata/golden/sonar-scan.json
+++ b/be-typescript-express/testdata/golden/sonar-scan.json
@@ -1,13 +1,12 @@
 {
-  "key": "unitt-typescript-iq-test",
-  "organization": "default-organization",
-  "name": "unitt-typescript-iq-test",
+  "key": "{{.ProjectID}}-{{.ComponentID}}",
+  "name": "{{.ProjectID}}-{{.ComponentID}}",
   "isFavorite": false,
   "visibility": "public",
   "extensions": [],
   "qualityProfiles": [
     {
-      "name": "Sonar way",
+      "name": "{{.SonarQualityProfile}}",
       "language": "ts",
       "deleted": false
     }
@@ -18,8 +17,8 @@
   },
   "breadcrumbs": [
     {
-      "key": "unitt-typescript-iq-test",
-      "name": "unitt-typescript-iq-test",
+      "key": "{{.ProjectID}}-{{.ComponentID}}",
+      "name": "{{.ProjectID}}-{{.ComponentID}}",
       "qualifier": "TRK"
     }
   ]

--- a/e2e-cypress/testdata/golden/sonar-scan.json
+++ b/e2e-cypress/testdata/golden/sonar-scan.json
@@ -1,18 +1,17 @@
 {
-  "key": "unitt-cypress",
-  "organization": "default-organization",
-  "name": "unitt-cypress",
+  "key": "{{.ProjectID}}-{{.ComponentID}}",
+  "name": "{{.ProjectID}}-{{.ComponentID}}",
   "isFavorite": false,
   "visibility": "public",
   "extensions": [],
   "qualityProfiles": [
     {
-      "name": "Sonar way",
+      "name": "{{.SonarQualityProfile}}",
       "language": "js",
       "deleted": false
     },
     {
-      "name": "Sonar way",
+      "name": "{{.SonarQualityProfile}}",
       "language": "ts",
       "deleted": false
     }
@@ -23,8 +22,8 @@
   },
   "breadcrumbs": [
     {
-      "key": "unitt-cypress",
-      "name": "unitt-cypress",
+      "key": "{{.ProjectID}}-{{.ComponentID}}",
+      "name": "{{.ProjectID}}-{{.ComponentID}}",
       "qualifier": "TRK"
     }
   ]

--- a/e2e-spock-geb/testdata/golden/sonar-scan.json
+++ b/e2e-spock-geb/testdata/golden/sonar-scan.json
@@ -1,18 +1,17 @@
 {
-  "key": "unitt-spock",
-  "organization": "default-organization",
-  "name": "unitt-spock",
+  "key": "{{.ProjectID}}-{{.ComponentID}}",
+  "name": "{{.ProjectID}}-{{.ComponentID}}",
   "isFavorite": false,
   "visibility": "public",
   "extensions": [],
   "qualityProfiles": [
     {
-      "name": "Sonar way",
+      "name": "{{.SonarQualityProfile}}",
       "language": "grvy",
       "deleted": false
     },
     {
-      "name": "Sonar way",
+      "name": "{{.SonarQualityProfile}}",
       "language": "java",
       "deleted": false
     }
@@ -23,8 +22,8 @@
   },
   "breadcrumbs": [
     {
-      "key": "unitt-spock",
-      "name": "unitt-spock",
+      "key": "{{.ProjectID}}-{{.ComponentID}}",
+      "name": "{{.ProjectID}}-{{.ComponentID}}",
       "qualifier": "TRK"
     }
   ]

--- a/fe-angular/testdata/golden/sonar-scan.json
+++ b/fe-angular/testdata/golden/sonar-scan.json
@@ -1,13 +1,12 @@
 {
-  "key": "unitt-fe-angular-test",
-  "organization": "default-organization",
-  "name": "unitt-fe-angular-test",
+  "key": "{{.ProjectID}}-{{.ComponentID}}",
+  "name": "{{.ProjectID}}-{{.ComponentID}}",
   "isFavorite": false,
   "visibility": "public",
   "extensions": [],
   "qualityProfiles": [
     {
-      "name": "Sonar way",
+      "name": "{{.SonarQualityProfile}}",
       "language": "ts",
       "deleted": false
     }
@@ -18,8 +17,8 @@
   },
   "breadcrumbs": [
     {
-      "key": "unitt-fe-angular-test",
-      "name": "unitt-fe-angular-test",
+      "key": "{{.ProjectID}}-{{.ComponentID}}",
+      "name": "{{.ProjectID}}-{{.ComponentID}}",
       "qualifier": "TRK"
     }
   ]

--- a/fe-ionic/testdata/golden/sonar-scan.json
+++ b/fe-ionic/testdata/golden/sonar-scan.json
@@ -1,13 +1,12 @@
 {
-  "key": "unitt-fe-ionic-test",
-  "organization": "default-organization",
-  "name": "unitt-fe-ionic-test",
+  "key": "{{.ProjectID}}-{{.ComponentID}}",
+  "name": "{{.ProjectID}}-{{.ComponentID}}",
   "isFavorite": false,
   "visibility": "public",
   "extensions": [],
   "qualityProfiles": [
     {
-      "name": "Sonar way",
+      "name": "{{.SonarQualityProfile}}",
       "language": "ts",
       "deleted": false
     }
@@ -18,8 +17,8 @@
   },
   "breadcrumbs": [
     {
-      "key": "unitt-fe-ionic-test",
-      "name": "unitt-fe-ionic-test",
+      "key": "{{.ProjectID}}-{{.ComponentID}}",
+      "name": "{{.ProjectID}}-{{.ComponentID}}",
       "qualifier": "TRK"
     }
   ]

--- a/ods-document-gen-svc/testdata/golden/sonar-scan.json
+++ b/ods-document-gen-svc/testdata/golden/sonar-scan.json
@@ -1,13 +1,12 @@
 {
-  "key": "unitt-docgen",
-  "organization": "default-organization",
-  "name": "unitt-docgen",
+  "key": "{{.ProjectID}}-{{.ComponentID}}",
+  "name": "{{.ProjectID}}-{{.ComponentID}}",
   "isFavorite": false,
   "visibility": "public",
   "extensions": [],
   "qualityProfiles": [
     {
-      "name": "Sonar way",
+      "name": "{{.SonarQualityProfile}}",
       "language": "grvy",
       "deleted": false
     }
@@ -18,8 +17,8 @@
   },
   "breadcrumbs": [
     {
-      "key": "unitt-docgen",
-      "name": "unitt-docgen",
+      "key": "{{.ProjectID}}-{{.ComponentID}}",
+      "name": "{{.ProjectID}}-{{.ComponentID}}",
       "qualifier": "TRK"
     }
   ]

--- a/ods-provisioning-app/testdata/golden/sonar-scan.json
+++ b/ods-provisioning-app/testdata/golden/sonar-scan.json
@@ -1,13 +1,12 @@
 {
-  "key": "unitt-provapp",
-  "organization": "default-organization",
-  "name": "unitt-provapp",
+  "key": "{{.ProjectID}}-{{.ComponentID}}",
+  "name": "{{.ProjectID}}-{{.ComponentID}}",
   "isFavorite": false,
   "visibility": "public",
   "extensions": [],
   "qualityProfiles": [
     {
-      "name": "Sonar way",
+      "name": "{{.SonarQualityProfile}}",
       "language": "java",
       "deleted": false
     }
@@ -18,8 +17,8 @@
   },
   "breadcrumbs": [
     {
-      "key": "unitt-provapp",
-      "name": "unitt-provapp",
+      "key": "{{.ProjectID}}-{{.ComponentID}}",
+      "name": "{{.ProjectID}}-{{.ComponentID}}",
       "qualifier": "TRK"
     }
   ]

--- a/release-manager/testdata/fixtures/metadata.yml
+++ b/release-manager/testdata/fixtures/metadata.yml
@@ -1,11 +1,11 @@
-id: unitt
-name: Project unitt
-description: Description of unitt.
+id: {{.ProjectID}}
+name: Project {{.ProjectID}}
+description: Description of {{.ProjectID}}.
 
 services:
   bitbucket:
     credentials:
-      id: unitt-cd-cd-user-with-password
+      id: {{.ProjectID}}-cd-cd-user-with-password
 
   nexus:
     repository:


### PR DESCRIPTION
In order to execute the automatic test in namespaces different than unitt we need to generalize several files, like the sonar-scan.json of the golden folder and the fixture of the metadata.yml for the release manager.
