### PR TITLE
Fix Angular Build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fixed Angular build for error "Unknown argument: sourceMap" ([#940](https://github.com/opendevstack/ods-quickstarters/pull/940))
 - Generate one xml report per spec and merge them later ([#898](https://github.com/opendevstack/ods-quickstarters/pull/898))
 - Addition of streamlit quickstarter ([#891](https://github.com/opendevstack/ods-quickstarters/issues/891))
 - Removal of Centos agents ([#1209](https://github.com/opendevstack/ods-core/issues/1209))

--- a/fe-angular/Jenkinsfile.template
+++ b/fe-angular/Jenkinsfile.template
@@ -25,7 +25,7 @@ def stageBuild(def context) {
       if ('master'.equals(context.gitBranch)) {
         sh 'npm run build'
       } else {
-        sh 'npm run build -- --sourceMap=true'
+        sh 'npm run build -- --source-map=true'
       }
     }
     sh "cp -r dist/${context.componentId} docker/dist"


### PR DESCRIPTION
In a recent build I have seen that Angular fails to build:
![image](https://github.com/opendevstack/ods-quickstarters/assets/26645694/7b8a537e-2f9b-4588-9268-b14d3bd707b0)


Acording to Angular Docs, we should use "--source-map" and not "--sourceMap"
![image](https://github.com/opendevstack/ods-quickstarters/assets/26645694/22c7805f-26ad-482f-8a97-bf48da7eba66)


