### PR TITLE
add chmod g=rwx $HOME to jenkins agent (#945)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Modified
 
 ### Fixed
+- jenkins agents can not import private keys into gpg keyring to use with helm secrets ([#945](https://github.com/opendevstack/ods-quickstarters/issues/945))
 
 ## [4.3.0] - 2023-07-13
 

--- a/common/jenkins-agents/jdk/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/jdk/docker/Dockerfile.ubi8
@@ -85,7 +85,7 @@ RUN mkdir -p $GRADLE_USER_HOME && \
 RUN bash -l -c 'echo export JAVA_OPTS="$(/tmp/set_java_proxy.sh && echo $JAVA_OPTS)" >> /etc/bash.bashrc'
 
 RUN chown -R 1001:0 $HOME && \
-    chmod -R g+rw $HOME && \
+    chmod -R g+rwX $HOME && \
     chmod -c 666 /etc/pki/ca-trust/extracted/java/cacerts && \
     ls -la /etc/pki/ca-trust/extracted/java/cacerts
 

--- a/common/jenkins-agents/nodejs12/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/nodejs12/docker/Dockerfile.ubi8
@@ -73,6 +73,6 @@ RUN npm config set registry=$nexusUrl/repository/npmjs/ && \
     echo yarn version: $(yarn --version)
 
 RUN chown -R 1001:0 $HOME && \
-    chmod -R g+rw $HOME
+    chmod -R g+rwX $HOME
 
 USER 1001

--- a/common/jenkins-agents/nodejs16/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/nodejs16/docker/Dockerfile.ubi8
@@ -57,6 +57,6 @@ RUN npm config set registry=$nexusUrl/repository/npmjs/ && \
     echo yarn version: $(yarn --version)
 
 RUN chown -R 1001:0 $HOME && \
-    chmod -R g+rw $HOME
+    chmod -R g+rwX $HOME
 
 USER 1001

--- a/common/jenkins-agents/nodejs18/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/nodejs18/docker/Dockerfile.ubi8
@@ -56,6 +56,6 @@ RUN npm config set registry=$nexusUrl/repository/npmjs/ && \
     echo yarn version: $(yarn --version)
 
 RUN chown -R 1001:0 $HOME && \
-    chmod -R g+rw $HOME
+    chmod -R g+rwX $HOME
 
 USER 1001

--- a/common/jenkins-agents/terraform-2306/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform-2306/docker/Dockerfile.ubi8
@@ -159,7 +159,7 @@ RUN dnf install -y https://github.com/mozilla/sops/releases/download/v${SOPS_VER
 
 RUN chmod +t /tmp \
     && chown -R 1001:0 $HOME \
-    && chmod -R g+rw $HOME \
+    && chmod -R g+rwX $HOME \
     && mkdir -p $GEM_HOME \
     && chmod 2770 $GEM_HOME
 

--- a/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/terraform/docker/Dockerfile.ubi8
@@ -147,7 +147,7 @@ RUN dnf install -y https://github.com/mozilla/sops/releases/download/v${SOPS_VER
 
 RUN chmod +t /tmp \
     && chown -R 1001:0 $HOME \
-    && chmod -R g+rw $HOME \
+    && chmod -R g+rwX $HOME \
     && mkdir -p $GEM_HOME \
     && chmod 2770 $GEM_HOME
 


### PR DESCRIPTION
this fixes the issue that the user used during pipeline run cannot access the child direcories created the image build. See #945 

Adds/Switches to `g=rwx` for affected jenkins-agents

Closes #945
Fixes #945
