### PR TITLE
change certificate source (ds-quickstarter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Modified
 
 ### Fixed
+- Streamlit quickstarter build fails to import nexus host certificates into truststore ([#951](https://github.com/opendevstack/ods-quickstarters/issues/951))
 
 ## [4.3.0] - 2023-07-13
 

--- a/ds-streamlit/files/docker_streamlit/Dockerfile
+++ b/ds-streamlit/files/docker_streamlit/Dockerfile
@@ -23,7 +23,7 @@ RUN chown -R 1001:0 /app && \
 WORKDIR /app
 
 # Install OS dependencies and update certs
-RUN openssl s_client -showcerts -host ${NEXUS_HOST} -port 443  </dev/null| \
+RUN openssl s_client -showcerts -host ${nexusHostWithoutScheme} -port 443  </dev/null| \
     sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /etc/pki/ca-trust/source/anchors/oc_app.crt && \
     update-ca-trust
  


### PR DESCRIPTION
Change NEXUS_HOST to nexusHostWithoutScheme to match build args in Jenkinsfile.

Closes #951 
Fixes #951

Tasks: 
- [ ] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
