### PR TITLE
Maintenance/955-maintenance-for-golang-agent-and-quickstarter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Modified
 
 ### Fixed
+- Maintenance for Golang Agent and QuickStarter ([#955](https://github.com/opendevstack/ods-quickstarters/issues/955))
 - jenkins agents can not import private keys into gpg keyring to use with helm secrets ([#945](https://github.com/opendevstack/ods-quickstarters/issues/945))
 - Streamlit quickstarter build fails to import nexus host certificates into truststore ([#951](https://github.com/opendevstack/ods-quickstarters/issues/951))
 

--- a/common/jenkins-agents/golang/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/golang/docker/Dockerfile.ubi8
@@ -2,7 +2,8 @@ FROM opendevstackorg/ods-jenkins-agent-base-ubi8:latest
 
 LABEL maintainer="Michael Sauter <michael.sauter@boehringer-ingelheim.com>"
 
-ARG goDistributionUrl
+ARG goDistributionUrl=https://go.dev/dl/go1.21.3.linux-amd64.tar.gz
+ARG golangciVersion=v1.54.2
 
 RUN yum install -y gcc gcc-c++
 
@@ -18,7 +19,7 @@ ENV PATH $PATH:/usr/local/go/bin
 ENV GOBIN /usr/local/bin
 
 COPY install-golangci-lint.sh /tmp/install-golangci-lint.sh
-RUN /tmp/install-golangci-lint.sh -b /usr/local/bin v1.52.2 && \
+RUN /tmp/install-golangci-lint.sh -b /usr/local/bin $golangciVersion && \
     rm -f /tmp/install-golangci-lint.sh
 
 RUN go install github.com/jstemmer/go-junit-report/v2@v2.0.0

--- a/common/jenkins-agents/golang/ocp-config/bc.yml
+++ b/common/jenkins-agents/golang/ocp-config/bc.yml
@@ -17,7 +17,7 @@ parameters:
   value: Dockerfile.ubi8
   description: Dockerfile variant to use
 - name: GO_DISTRIBUTION_URL
-  value: https://go.dev/dl/go1.20.4.linux-amd64.tar.gz
+  value: https://go.dev/dl/go1.21.3.linux-amd64.tar.gz
   description: URL pointing to go binary
 objects:
 - apiVersion: v1

--- a/docs/modules/jenkins-agents/pages/golang.adoc
+++ b/docs/modules/jenkins-agents/pages/golang.adoc
@@ -7,8 +7,8 @@ The image is built in the global `ods` project and is named `jenkins-agent-golan
 It can be referenced in a `Jenkinsfile` with e.g. `ods/jenkins-agent-golang:latest`.
 
 == Features
-1. Go 1.20.x
-2. golangci-lint 1.52.x
+1. Go 1.21.x
+2. golangci-lint 1.54.x
 
 == Known limitations
 Not (yet) Nexus package manager aware and no special HTTP Proxy configuration.


### PR DESCRIPTION
fixes #955 Maintenance for Golang Agent and Quickstarter

Closes #955
Fixes #955

Tasks: 
- [x] Updated documentation in `docs/modules/...` directory
- [x] **NOTE: no tests present in the directory** -- Ran tests in `<quickstarter>/testdata` directory
