### PR TITLE
Update Gateway-Nginx quickstarter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Added
+- Update gateway-Nginx quickstarter ([#983](https://github.com/opendevstack/ods-quickstarters/pull/983))
 - Added secret scanning in docker plain ([#963](https://github.com/opendevstack/ods-quickstarters/pull/963))
 - Added Nodejs20 agent ([#962](https://github.com/opendevstack/ods-quickstarters/issues/962))
 - Update release manager readme ([#969](https://github.com/opendevstack/ods-quickstarters/issues/969))

--- a/be-gateway-nginx/files/docker/Dockerfile
+++ b/be-gateway-nginx/files/docker/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/openresty/docker-openresty
-FROM openresty/openresty:1.21.4.1-rocky
+FROM openresty/openresty:1.25.3.1-1-rocky
 
 ENV LANG=C.UTF-8
 

--- a/be-gateway-nginx/files/metadata.yml
+++ b/be-gateway-nginx/files/metadata.yml
@@ -1,6 +1,6 @@
 ---
 name: nginx
-description: "Enhanced nginx with Lua embeded. nginx [engine x] is an HTTP and reverse proxy server, a mail proxy server, and a generic TCP/UDP proxy server. Technologies: OpenResty/nginx 1.19.3.2"
+description: "Enhanced nginx with Lua embeded. nginx [engine x] is an HTTP and reverse proxy server, a mail proxy server, and a generic TCP/UDP proxy server. Technologies: OpenResty/nginx 1.25.3.1-1"
 supplier: https://openresty.org
 version: 4.x
 type: ods-service

--- a/docs/modules/quickstarters/pages/be-gateway-nginx.adoc
+++ b/docs/modules/quickstarters/pages/be-gateway-nginx.adoc
@@ -109,9 +109,9 @@ Note that the xref:jenkins-shared-library:labelling.adoc[OpenShift resources wil
 
 ```yaml
 name: nginx
-description: "Enhanced nginx with Lua embeded. nginx [engine x] is an HTTP and reverse proxy server, a mail proxy server, and a generic TCP/UDP proxy server. Technologies: OpenResty/nginx 1.19.3.2"
+description: "Enhanced nginx with Lua embeded. nginx [engine x] is an HTTP and reverse proxy server, a mail proxy server, and a generic TCP/UDP proxy server. Technologies: OpenResty/nginx 1.25.3.1-1"
 supplier: https://openresty.org
-version: 1.21.4.1
+version: 1.25.3.1-1
 type: ods-service
 role: integration
 ```


### PR DESCRIPTION
Update gateway nginx quickstarter to version 1.25.3.1-1

- [x] Provision successfull
- [x] Build successfull
- [x] Example app working