### PR TITLE
rust qs set cargo tools versions and no compile but get bins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Modified
 - Remove nodejs12 form the code ([#936](https://github.com/opendevstack/ods-quickstarters/issues/936))
+- Rust Quickstarter Jenkins Agent CICD tools with fixed versions ([#988](https://github.com/opendevstack/ods-quickstarters/issues/988))
 
 ### Fixed
 - Maintenance for Golang Agent and QuickStarter ([#955](https://github.com/opendevstack/ods-quickstarters/issues/955))

--- a/common/jenkins-agents/rust/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/rust/docker/Dockerfile.ubi8
@@ -7,6 +7,9 @@ ARG rustToolchain
 
 ENV PATH="$HOME/.cargo/bin:$PATH"
 ENV USER="rust-agent"
+ENV CARGO_NEXTEST_VERSION=0.9.67 \
+    CARGO_LLVM_COV_VERSION=0.6.4 \
+    CARGO_GENERATE_VERSION=0.19.0
 
 RUN yum install -y binutils cpp gcc glibc-devel glibc-headers isl kernel-headers libasan libatomic libgomp libmpc libpkgconf libubsan libxcrypt-devel llvm-libs pkgconf pkgconf-m4 pkgconf-pkg-config openssl-devel
 
@@ -17,7 +20,16 @@ RUN cd /tmp && \
     cd rust-${rustVersion}-${rustToolchain} && \
     ./install.sh && \
     cargo -V && \
-    cargo install cargo-nextest cargo-llvm-cov cargo-generate
+    mkdir -p $HOME/.cargo/bin && \
+    # Download binaries and install to $HOME/.cargo/bin
+    curl --proto '=https' --tlsv1.2 -fsSL https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-$CARGO_NEXTEST_VERSION/cargo-nextest-$CARGO_NEXTEST_VERSION-$rustToolchain.tar.gz | tar xzf - -C "$HOME/.cargo/bin" && \
+    curl --proto '=https' --tlsv1.2 -fsSL https://github.com/cargo-generate/cargo-generate/releases/download/v$CARGO_GENERATE_VERSION/cargo-generate-v$CARGO_GENERATE_VERSION-$rustToolchain.tar.gz | tar xzf - -C "$HOME/.cargo/bin" && \
+    # curl --proto '=https' --tlsv1.2 -fsSL https://github.com/taiki-e/cargo-llvm-cov/releases/download/v$CARGO_LLVM_COV_VERSION/cargo-llvm-cov-$rustToolchain.tar.gz | tar xzf - -C "$HOME/.cargo/bin" && \
+    # cargo LLVM coverage crate is recommended to be compiled as it takes care to add the OS lib dependencies the proper way
+    cargo install cargo-llvm-cov --version $CARGO_LLVM_COV_VERSION && \
+    cargo nextest --version && \
+    cargo llvm-cov --version && \
+    cargo generate --version
 
 RUN chgrp -R 0 $HOME/.cargo && \
     chmod -R g=u $HOME/.cargo


### PR DESCRIPTION
Fix Rust Quickstarter Jenkins Agent CICD cargo tools versions.

Fixes #988 988

Tasks: 
- [x] Updated documentation in `docs/modules/...` directory
- [x] Ran tests in `<quickstarter>/testdata` directory
