### PR TITLE
Update deprecated apiVersion in ocp templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added secret scanning in docker plain ([#963](https://github.com/opendevstack/ods-quickstarters/pull/963))
+- Update api version in ocp templates for image, buildconfig, route and deploymentconfig ([#1072](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1072))
 
 ## [4.3.1] - 2024-02-19
 

--- a/be-fe-mono-repo-plain/openshift/component-template.yml
+++ b/be-fe-mono-repo-plain/openshift/component-template.yml
@@ -68,7 +68,7 @@ objects:
         deploymentconfig: '${COMPONENT}'
       sessionAffinity: None
       type: ClusterIP
-  - apiVersion: v1
+  - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig
     metadata:
       name: '${COMPONENT}'

--- a/common/jenkins-agents/golang/ocp-config/bc.yml
+++ b/common/jenkins-agents/golang/ocp-config/bc.yml
@@ -20,7 +20,7 @@ parameters:
   value: https://go.dev/dl/go1.21.3.linux-amd64.tar.gz
   description: URL pointing to go binary
 objects:
-- apiVersion: v1
+- apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     name: jenkins-agent-golang

--- a/common/jenkins-agents/golang/ocp-config/is.yml
+++ b/common/jenkins-agents/golang/ocp-config/is.yml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: jenkins-agent-golang
 objects:
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     name: jenkins-agent-golang

--- a/common/jenkins-agents/jdk/ocp-config/bc.yml
+++ b/common/jenkins-agents/jdk/ocp-config/bc.yml
@@ -23,7 +23,7 @@ parameters:
   value: Dockerfile.ubi8
   description: Dockerfile variant to use
 objects:
-- apiVersion: v1
+- apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     name: jenkins-agent-jdk

--- a/common/jenkins-agents/jdk/ocp-config/is.yml
+++ b/common/jenkins-agents/jdk/ocp-config/is.yml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: jenkins-agent-jdk
 objects:
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     name: jenkins-agent-jdk

--- a/common/jenkins-agents/nodejs16/ocp-config/bc.yml
+++ b/common/jenkins-agents/nodejs16/ocp-config/bc.yml
@@ -21,7 +21,7 @@ parameters:
   value: Dockerfile.ubi8
   description: Dockerfile variant to use
 objects:
-- apiVersion: v1
+- apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     name: jenkins-agent-nodejs16

--- a/common/jenkins-agents/nodejs16/ocp-config/is.yml
+++ b/common/jenkins-agents/nodejs16/ocp-config/is.yml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: jenkins-agent-nodejs16
 objects:
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     name: jenkins-agent-nodejs16

--- a/common/jenkins-agents/nodejs18/ocp-config/bc.yml
+++ b/common/jenkins-agents/nodejs18/ocp-config/bc.yml
@@ -21,7 +21,7 @@ parameters:
   value: Dockerfile.ubi8
   description: Dockerfile variant to use
 objects:
-- apiVersion: v1
+- apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     name: jenkins-agent-nodejs18

--- a/common/jenkins-agents/nodejs18/ocp-config/is.yml
+++ b/common/jenkins-agents/nodejs18/ocp-config/is.yml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: jenkins-agent-nodejs18
 objects:
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     name: jenkins-agent-nodejs18

--- a/common/jenkins-agents/nodejs20/ocp-config/bc.yml
+++ b/common/jenkins-agents/nodejs20/ocp-config/bc.yml
@@ -21,7 +21,7 @@ parameters:
   value: Dockerfile.ubi8
   description: Dockerfile variant to use
 objects:
-- apiVersion: v1
+- apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     name: jenkins-agent-nodejs20

--- a/common/jenkins-agents/nodejs20/ocp-config/is.yml
+++ b/common/jenkins-agents/nodejs20/ocp-config/is.yml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: jenkins-agent-nodejs20
 objects:
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     name: jenkins-agent-nodejs20

--- a/common/jenkins-agents/python/ocp-config/bc.yml
+++ b/common/jenkins-agents/python/ocp-config/bc.yml
@@ -23,7 +23,7 @@ parameters:
   description: "Your Nexus Authentication credentials: username:password"
   required: true
 objects:
-- apiVersion: v1
+- apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     name: jenkins-agent-python

--- a/common/jenkins-agents/python/ocp-config/is.yml
+++ b/common/jenkins-agents/python/ocp-config/is.yml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: jenkins-agent-python
 objects:
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     name: jenkins-agent-python

--- a/common/jenkins-agents/rust/ocp-config/bc.yml
+++ b/common/jenkins-agents/rust/ocp-config/bc.yml
@@ -25,7 +25,7 @@ parameters:
   required: true
   value: "x86_64-unknown-linux-gnu"
 objects:
-- apiVersion: v1
+- apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     name: jenkins-agent-rust

--- a/common/jenkins-agents/rust/ocp-config/is.yml
+++ b/common/jenkins-agents/rust/ocp-config/is.yml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: jenkins-agent-rust
 objects:
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     name: jenkins-agent-rust

--- a/common/jenkins-agents/scala/ocp-config/bc.yml
+++ b/common/jenkins-agents/scala/ocp-config/bc.yml
@@ -23,7 +23,7 @@ parameters:
   value: Dockerfile.ubi8
   description: Dockerfile variant to use
 objects:
-- apiVersion: v1
+- apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     name: jenkins-agent-scala

--- a/common/jenkins-agents/scala/ocp-config/is.yml
+++ b/common/jenkins-agents/scala/ocp-config/is.yml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: jenkins-agent-scala
 objects:
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     name: jenkins-agent-scala

--- a/common/jenkins-agents/terraform-2306/ocp-config/bc.yml
+++ b/common/jenkins-agents/terraform-2306/ocp-config/bc.yml
@@ -17,7 +17,7 @@ parameters:
   value: Dockerfile.ubi8
   description: Dockerfile variant to use
 objects:
-- apiVersion: v1
+- apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     name: jenkins-agent-terraform-2306

--- a/common/jenkins-agents/terraform-2306/ocp-config/is.yml
+++ b/common/jenkins-agents/terraform-2306/ocp-config/is.yml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: jenkins-agent-terraform-2306
 objects:
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     name: jenkins-agent-terraform-2306

--- a/common/jenkins-agents/terraform/ocp-config/bc.yml
+++ b/common/jenkins-agents/terraform/ocp-config/bc.yml
@@ -17,7 +17,7 @@ parameters:
   value: Dockerfile.ubi8
   description: Dockerfile variant to use
 objects:
-- apiVersion: v1
+- apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     name: jenkins-agent-terraform

--- a/common/jenkins-agents/terraform/ocp-config/is.yml
+++ b/common/jenkins-agents/terraform/ocp-config/is.yml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: jenkins-agent-terraform
 objects:
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     name: jenkins-agent-terraform

--- a/common/ocp-config/component-environment/component-template.yml
+++ b/common/ocp-config/component-environment/component-template.yml
@@ -53,7 +53,7 @@ objects:
         deploymentconfig: "${COMPONENT}"
       sessionAffinity: None
       type: ClusterIP
-  - apiVersion: v1
+  - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig
     metadata:
       name: "${COMPONENT}"

--- a/common/ocp-config/component-oauth-sidecar/component-oauth-sidecar.yml
+++ b/common/ocp-config/component-oauth-sidecar/component-oauth-sidecar.yml
@@ -86,7 +86,7 @@ objects:
       sessionAffinity: None
       type: ClusterIP
 
-  - apiVersion: v1
+  - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:
       name: ${COMPONENT}
@@ -106,7 +106,7 @@ objects:
       annotations:
         serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"${COMPONENT}"}}'
 
-  - apiVersion: v1
+  - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig
     metadata:
       creationTimestamp: null

--- a/common/ocp-config/component/template.yml
+++ b/common/ocp-config/component/template.yml
@@ -80,7 +80,7 @@ objects:
       deploymentconfig: "${COMPONENT}"
     sessionAffinity: None
     type: ClusterIP
-- apiVersion: v1
+- apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
     name: "${COMPONENT}"

--- a/release-manager/ocp-config/cd-docgen.yml
+++ b/release-manager/ocp-config/cd-docgen.yml
@@ -55,7 +55,7 @@ objects:
         deploymentconfig: docgen
       sessionAffinity: None
       type: ClusterIP
-  - apiVersion: v1
+  - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig
     metadata:
       labels:

--- a/release-manager/ocp-config/cd-pipeline.yml
+++ b/release-manager/ocp-config/cd-pipeline.yml
@@ -18,7 +18,7 @@ parameters:
     description: The trigger secret for the pipeline.
     required: true
 objects:
-  - apiVersion: v1
+  - apiVersion: build.openshift.io/v1
     kind: BuildConfig
     metadata:
       labels:


### PR DESCRIPTION
Fix https://github.com/opendevstack/ods-jenkins-shared-library/issues/1072 for ods-quickstarters repository
