### PR TITLE
Rust agent Build Config typo

### DIFF
--- a/common/jenkins-agents/rust/ocp-config/bc.yml
+++ b/common/jenkins-agents/rust/ocp-config/bc.yml
@@ -37,7 +37,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: jenkins-agent-python:${ODS_IMAGE_TAG}
+        name: jenkins-agent-rust:${ODS_IMAGE_TAG}
     postCommit: {}
     resources:
       limits:


### PR DESCRIPTION

Fix typo in Rust agent BC