### PR TITLE
add chmod X permissions to group in $HOME to jenkins agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added secret scanning in docker plain ([#963](https://github.com/opendevstack/ods-quickstarters/pull/963))
 - Update api version in ocp templates for image, buildconfig, route and deploymentconfig ([#1072](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1072))
 - Update Makefile adding all missing agents ([#999](https://github.com/opendevstack/ods-quickstarters/pull/999))
+- jenkins agent nodejs20 can not import private keys into gpg keyring to use with helm secrets ([#1001](https://github.com/opendevstack/ods-quickstarters/issues/1001))
 
 ## [4.3.1] - 2024-02-19
 

--- a/common/jenkins-agents/nodejs20/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/nodejs20/docker/Dockerfile.ubi8
@@ -56,6 +56,6 @@ RUN npm config set registry=$nexusUrl/repository/npmjs/ && \
     echo yarn version: $(yarn --version)
 
 RUN chown -R 1001:0 $HOME && \
-    chmod -R g+rw $HOME
+    chmod -R g+rwX $HOME
 
 USER 1001


### PR DESCRIPTION
this fixes the issue that the user used during pipeline run cannot access the child directories created the image build in jenkins-agent-nodejs20. See https://github.com/opendevstack/ods-quickstarters/issues/1001

Adds X group permissions to $HOME for jenkins-agent-nodejs20

Closes #1001 
Fixes #1001 