### PR TITLE
switch to centos vault repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,6 @@
 
 ### Fixed
 
-## [4.5.1] - 2024-06-07
-
-### Fixed
-- Workaround for centos 8 stream repository deprecation ([#1021](https://github.com/opendevstack/ods-quickstarters/issues/1021))
-
 ## [4.5.0] - 2024-06-06
 
 ### Added
@@ -21,6 +16,9 @@
 ### Changed
 - Update Ionic Quickstarter ([#1009](https://github.com/opendevstack/ods-quickstarters/pull/1009))
 - Update Angular Quickstarter ([#1019](https://github.com/opendevstack/ods-quickstarters/pull/1019))
+
+### Fixed
+- Workaround for centos 8 stream repository deprecation ([#1021](https://github.com/opendevstack/ods-quickstarters/issues/1021))
 
 ## [4.4.0] - 2024-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Fixed
 
+## [4.5.1] - 2024-06-07
+
+### Fixed
+- Workaround for centos 8 stream repository deprecation ([#1021](https://github.com/opendevstack/ods-quickstarters/issues/1021))
+
 ## [4.5.0] - 2024-06-06
 
 ### Added

--- a/common/jenkins-agents/nodejs16/docker/yum.repos.d/centos8.repo
+++ b/common/jenkins-agents/nodejs16/docker/yum.repos.d/centos8.repo
@@ -1,13 +1,13 @@
 [centos-baseos]
 name=CentOS-8-BaseOS
-baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
+baseurl=https://vault.centos.org/centos/8-stream/BaseOS/x86_64/os/
 enabled=1
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 
 [centos-appstream]
 name=CentOS-8-AppStream
-baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
+baseurl=https://vault.centos.org/centos/8-stream/AppStream/x86_64/os/
 enabled=1
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official

--- a/common/jenkins-agents/nodejs18/docker/yum.repos.d/centos8.repo
+++ b/common/jenkins-agents/nodejs18/docker/yum.repos.d/centos8.repo
@@ -1,13 +1,13 @@
 [centos-baseos]
 name=CentOS-8-BaseOS
-baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
+baseurl=https://vault.centos.org/centos/8-stream/BaseOS/x86_64/os/
 enabled=1
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 
 [centos-appstream]
 name=CentOS-8-AppStream
-baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
+baseurl=https://vault.centos.org/centos/8-stream/AppStream/x86_64/os/
 enabled=1
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official

--- a/common/jenkins-agents/nodejs20/docker/yum.repos.d/centos8.repo
+++ b/common/jenkins-agents/nodejs20/docker/yum.repos.d/centos8.repo
@@ -1,13 +1,13 @@
 [centos-baseos]
 name=CentOS-8-BaseOS
-baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
+baseurl=https://vault.centos.org/centos/8-stream/BaseOS/x86_64/os/
 enabled=1
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 
 [centos-appstream]
 name=CentOS-8-AppStream
-baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
+baseurl=https://vault.centos.org/centos/8-stream/AppStream/x86_64/os/
 enabled=1
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official

--- a/common/jenkins-agents/nodejs22/docker/yum.repos.d/centos8.repo
+++ b/common/jenkins-agents/nodejs22/docker/yum.repos.d/centos8.repo
@@ -1,13 +1,13 @@
 [centos-baseos]
 name=CentOS-8-BaseOS
-baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
+baseurl=https://vault.centos.org/centos/8-stream/BaseOS/x86_64/os/
 enabled=1
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 
 [centos-appstream]
 name=CentOS-8-AppStream
-baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
+baseurl=https://vault.centos.org/centos/8-stream/AppStream/x86_64/os/
 enabled=1
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official

--- a/common/jenkins-agents/terraform-2306/docker/yum.repos.d/centos8.repo
+++ b/common/jenkins-agents/terraform-2306/docker/yum.repos.d/centos8.repo
@@ -2,8 +2,8 @@
 name=CentOS-8 - Base
 #mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=os&infra=centos
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
-baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
+#baseurl=https://vault.centos.org/centos/$releasever/os/$basearch/
+baseurl=https://vault.centos.org/centos/8-stream/BaseOS/x86_64/os/
 gpgcheck=1
 gpgkey=https://centos.org/keys/RPM-GPG-KEY-CentOS-Official
 enabled=0
@@ -12,8 +12,8 @@ enabled=0
 [centos-extras]
 name=CentOS-8 - Extras
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
-baseurl=http://mirror.centos.org/centos/8-stream/extras/x86_64/os/
+#baseurl=https://vault.centos.org/centos/$releasever/extras/$basearch/
+baseurl=https://vault.centos.org/centos/8-stream/extras/x86_64/os/
 gpgcheck=1
 gpgkey=https://centos.org/keys/RPM-GPG-KEY-CentOS-Official
 enabled=0
@@ -22,15 +22,15 @@ enabled=0
 [centos-plus]
 name=CentOS-8 - Plus
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
-baseurl=http://mirror.centos.org/centos/8-stream/centosplus/x86_64/os/
+#baseurl=https://vault.centos.org/centos/$releasever/centosplus/$basearch/
+baseurl=https://vault.centos.org/centos/8-stream/centosplus/x86_64/os/
 gpgcheck=1
 enabled=0
 gpgkey=https://centos.org/keys/RPM-GPG-KEY-CentOS-Official
 
 [centos-appstream]
 name=CentOS-8-AppStream
-baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
+baseurl=https://vault.centos.org/centos/8-stream/AppStream/x86_64/os/
 enabled=0
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
@@ -39,8 +39,8 @@ gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 name=CentOS-8 - Devel
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
-baseurl=http://mirror.centos.org/centos/8-stream/Devel/x86_64/os/
+#baseurl=https://vault.centos.org/centos/$releasever/updates/$basearch/
+baseurl=https://vault.centos.org/centos/8-stream/Devel/x86_64/os/
 gpgcheck=1
 gpgkey=https://centos.org/keys/RPM-GPG-KEY-CentOS-Official
 enabled=0

--- a/common/jenkins-agents/terraform/docker/yum.repos.d/centos8.repo
+++ b/common/jenkins-agents/terraform/docker/yum.repos.d/centos8.repo
@@ -2,8 +2,8 @@
 name=CentOS-8 - Base
 #mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=os&infra=centos
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
-baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
+#baseurl=https://vault.centos.org/centos/$releasever/os/$basearch/
+baseurl=https://vault.centos.org/centos/8-stream/BaseOS/x86_64/os/
 gpgcheck=1
 gpgkey=https://centos.org/keys/RPM-GPG-KEY-CentOS-Official
 enabled=0
@@ -12,8 +12,8 @@ enabled=0
 [centos-extras]
 name=CentOS-8 - Extras
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
-baseurl=http://mirror.centos.org/centos/8-stream/extras/x86_64/os/
+#baseurl=https://vault.centos.org/centos/$releasever/extras/$basearch/
+baseurl=https://vault.centos.org/centos/8-stream/extras/x86_64/os/
 gpgcheck=1
 gpgkey=https://centos.org/keys/RPM-GPG-KEY-CentOS-Official
 enabled=0
@@ -22,15 +22,15 @@ enabled=0
 [centos-plus]
 name=CentOS-8 - Plus
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
-baseurl=http://mirror.centos.org/centos/8-stream/centosplus/x86_64/os/
+#baseurl=https://vault.centos.org/centos/$releasever/centosplus/$basearch/
+baseurl=https://vault.centos.org/centos/8-stream/centosplus/x86_64/os/
 gpgcheck=1
 enabled=0
 gpgkey=https://centos.org/keys/RPM-GPG-KEY-CentOS-Official
 
 [centos-appstream]
 name=CentOS-8-AppStream
-baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
+baseurl=https://vault.centos.org/centos/8-stream/AppStream/x86_64/os/
 enabled=0
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
@@ -39,8 +39,8 @@ gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 name=CentOS-8 - Devel
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
-baseurl=http://mirror.centos.org/centos/8-stream/Devel/x86_64/os/
+#baseurl=https://vault.centos.org/centos/$releasever/updates/$basearch/
+baseurl=https://vault.centos.org/centos/8-stream/Devel/x86_64/os/
 gpgcheck=1
 gpgkey=https://centos.org/keys/RPM-GPG-KEY-CentOS-Official
 enabled=0


### PR DESCRIPTION
Switch to centos vault repository as a temporal solution, as the snapshop has been done the 31st of May 2024

workarround to #1021 
