### PR TITLE
Adds readme doc about gradle cache in pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Update Rust Axum Quickstarter ([#1024](https://github.com/opendevstack/ods-quickstarters/pull/1024))
 - Gitleaks docs fix and update ([#1028](https://github.com/opendevstack/ods-quickstarters/issues/1028))
 - Enable OpenSSL vendored compilation for Rust Jenkins Agent ([#1026](https://github.com/opendevstack/ods-quickstarters/pull/1026))
+- Add documentation for adding gradle-cache to build pipeline ([#1043](https://github.com/opendevstack/ods-quickstarters/issues/1043))
 
 ### Added
 

--- a/be-java-springboot/Jenkinsfile
+++ b/be-java-springboot/Jenkinsfile
@@ -79,5 +79,11 @@ odsQuickstarterPipeline(
 
   odsQuickstarterStageRenderJenkinsfile(context)
 
+  odsQuickstarterStageRenderJenkinsfile(
+    context,
+    [source: 'README.md.template',
+     target: 'README.md']
+  )
+
   odsQuickstarterStageRenderSonarProperties(context)
 }

--- a/be-java-springboot/README.md.template
+++ b/be-java-springboot/README.md.template
@@ -6,7 +6,12 @@ The official OpenDevStack documentation for this QuickStarter can be found [here
 
 One can improve the build pipeline time by adding a Gradle cache. This way, `gradlew` can use 
 previously downloaded distributions instead of downloading them from the internet on every build.
-To do so, follow the steps below:
+
+> **Note:** As the Jenkins jobs are sharing the same PVC with access mode `ReadWriteOnce`,
+only one Jenkins job accessing this PVC can run at a time. The Gradle cache locking mechanism
+does not support multiple processes working on it simultaneously.
+
+To add a PVC for the cache and add it to your pipeline, follow the steps below:
 
 - Create a `PersistentVolumeClaim` (PVC) with the name `gradle-cache` in your `@project_id@-cd`-namespace,
 either via the OpenShift UI or via `oc` like this:
@@ -55,5 +60,3 @@ def stageBuild(def context) {
 }
 ...
 ```
-
-**NOTE**: Be aware that, as the Jenkins jobs are sharing the same PVC, only one Jenkins job can run at a time.

--- a/be-java-springboot/README.md.template
+++ b/be-java-springboot/README.md.template
@@ -1,4 +1,4 @@
-# {{project-name}} - provisioned from the OpenDevStack Java/Spring Boot QuickStarter (be-java-springboot)
+# @project_id@-@component_id@ - provisioned from the OpenDevStack Java/Spring Boot QuickStarter (be-java-springboot)
 
 The official OpenDevStack documentation for this QuickStarter can be found [here](https://www.opendevstack.org/ods-documentation/opendevstack/latest/quickstarters/be-java-springboot.html).
 
@@ -8,7 +8,7 @@ One can improve the build pipeline time by adding a Gradle cache. This way, `gra
 previously downloaded distributions instead of downloading them from the internet on every build.
 To do so, follow the steps below:
 
-- Create a `PersistentVolumeClaim` (PVC) with the name `gradle-cache` in your `{{project-name}}-cd`-namespace,
+- Create a `PersistentVolumeClaim` (PVC) with the name `gradle-cache` in your `@project_id@-cd`-namespace,
 either via the OpenShift UI or via `oc` like this:
 ```
 oc create -n {{project-name}}-cd -f - <<EOF

--- a/be-java-springboot/files/README.md
+++ b/be-java-springboot/files/README.md
@@ -1,0 +1,59 @@
+# {{project-name}} - provisioned from the OpenDevStack Java/Spring Boot QuickStarter (be-java-springboot)
+
+The official OpenDevStack documentation for this QuickStarter can be found [here](https://www.opendevstack.org/ods-documentation/opendevstack/latest/quickstarters/be-java-springboot.html).
+
+### Adding Gradle cache to your CI/CD pipeline
+
+One can improve the build pipeline time by adding a Gradle cache. This way, `gradlew` can use 
+previously downloaded distributions instead of downloading them from the internet on every build.
+To do so, follow the steps below:
+
+- Create a `PersistentVolumeClaim` (PVC) with the name `gradle-cache` in your `{{project-name}}-cd`-namespace,
+either via the OpenShift UI or via `oc` like this:
+```
+oc create -n {{project-name}}-cd -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+name: gradle-cache
+spec:
+accessModes:
+- ReadWriteOnce
+resources:
+requests:
+storage: 2Gi
+EOF
+```
+The above needs to be done only once per project, as this PVC can be reused for other components within the same project.
+
+- In your `Jenkinsfile`, mount this PVC to the containers of the pipeline by adding it as a podVolume:
+```
+...
+odsComponentPipeline(
+  podContainers: [
+    ...
+  ],
+  podVolumes: [
+    persistentVolumeClaim(claimName: "gradle-cache", mountPath: "/.gradle-cache", readOnly: false)
+  ],
+  branchToEnvironmentMapping: [
+    ...
+  ]
+)
+...
+```
+
+- Add this mount path as an env var called `GRADLE_USER_HOME` in the build stage to be picked up by Gradle:
+```
+...
+def stageBuild(def context) {
+  stage('Build and Unit Test') {
+    withEnv(["TAGVERSION=${context.tagversion}",...,"GRADLE_USER_HOME=/.gradle-cache",...]) {
+      ...
+    }
+  }
+}
+...
+```
+
+**NOTE**: Be aware that, as the Jenkins jobs are sharing the same PVC, only one Jenkins job can run at a time.


### PR DESCRIPTION
Added readme file to springboot QS and added section for using gradle cache in the pipeline

Closes #1043

