### PR TITLE
Fix permision for golden tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Update Rust Axum Quickstarter to Rust 1.80.1 and improve Agent build configuration ([#1040](https://github.com/opendevstack/ods-quickstarters/pull/1040))
 - Support for Python3.12, and maintenance of be-python-flask quickstarter and python Jenkins agent ([#1030](https://github.com/opendevstack/ods-quickstarters/pull/1030))
 - Added custom reporter to Cypress Quickstarter and update dependencies ([#1034](https://github.com/opendevstack/ods-quickstarters/pull/1034))
+- Fix permissions in Golang agent for the golden tests ([#1052](https://github.com/opendevstack/ods-quickstarters/pull/1052))
 
 ### Added
 

--- a/common/jenkins-agents/golang/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/golang/docker/Dockerfile.ubi8
@@ -22,6 +22,6 @@ RUN /tmp/install-golangci-lint.sh -b /usr/local/bin $golangciVersion && \
 
 RUN go install github.com/jstemmer/go-junit-report/v2@v2.1.0
 
-RUN mkdir -p /home/jenkins/go && chmod g+w /home/jenkins/go
+RUN mkdir -p /home/jenkins/go && chmod -R g+w /home/jenkins
 
 WORKDIR /go


### PR DESCRIPTION
As we are preparing to use the Quickstarters golden tests officially, we are also updating the Golang version they use (from go 1.13 to 1.23).
In the tests we did with the latest Golang agent we found out that we face permission issues in the Jenkins home folder so we need to change it.
