### PR TITLE
Remove obsolete branch param from release-manager starter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove obsolete branch parameter from release-manager ([#1058](https://github.com/opendevstack/ods-quickstarters/pull/1058))
 - Update OS packages by default and bump gitleaks version ([#1049](https://github.com/opendevstack/ods-quickstarters/issues/1049))
 - Install java 17 devel only in scala and jdk agents ([#1057](https://github.com/opendevstack/ods-quickstarters/pull/1057))
 - Update Angular, Ionic and Typescript Quickstarters ([#1033](https://github.com/opendevstack/ods-quickstarters/issues/1033))

--- a/docs/modules/quickstarters/pages/release-manager.adoc
+++ b/docs/modules/quickstarters/pages/release-manager.adoc
@@ -25,13 +25,12 @@ name: Project Phoenix
 
 repositories:
   - id: A
-    branch: master
   - id: B
     name: my-repo-B
-    branch: master
   - id: C
 ----
 
+For all repositories mentioned above (A, B, C) the library will resolve the default branch configured in each.
 If a named repository wants to announce a dependency on another repo, the dependency needs to be listed in that repository's `release-manager.yml`, simply by referring to its `repo.id` as defined in `metadata.yml`:
 
 ----
@@ -47,11 +46,9 @@ name: Project Phoenix
 
 repositories:
   - id: A
-    branch: master
     type: ods
   - id: B
     name: my-repo-B
-    branch: master
     type: ods
   - id: C
     type: ods
@@ -85,7 +82,6 @@ name: Project Phoenix
 repositories:
   - id: B
     name: my-repo-B
-    branch: master
 ----
 
 Assuming your release manager component's origin at `https://github.com/my-org/my-pipeline.git` in this example, the Git URL for repository `B` will resolve to `https://github.com/my-org/my-repo-B.git`, based on the value in `repositories[0].name`.
@@ -104,7 +100,7 @@ Assuming your release manager component's origin at `https://github.com/my-org/m
 
 === Automated Resolution of Repository Branch
 
-If no `branch` parameter is provided for a repository, `master` will be assumed.
+The default branch configured for the repository will be considered.
 
 === Automated Parallelization of Repositories
 

--- a/release-manager/files/README.md
+++ b/release-manager/files/README.md
@@ -24,13 +24,11 @@ name: Project Phoenix
 
 repositories:
   - id: A
-    branch: master
   - id: B
     name: my-repo-B
-    branch: master
   - id: C
 ```
-
+For all repositories mentioned above (A, B, C) the library will resolve the default branch configured in each.
 If a named repository wants to announce a dependency on another repo, the dependency needs to be listed in that repository's `release-manager.yml`, simply by referring to its `repo.id` as defined in `metadata.yml`:
 
 ```
@@ -46,11 +44,9 @@ name: Project Phoenix
 
 repositories:
   - id: A
-    branch: master
     type: ods
   - id: B
     name: my-repo-B
-    branch: master
     type: ods
   - id: C
     type: ods
@@ -98,7 +94,6 @@ name: Project Phoenix
 repositories:
   - id: B
     name: my-repo-B
-    branch: master
 ```
 
 Assuming your release manager component's origin at `https://github.com/my-org/my-pipeline.git` in this example, the Git URL for repository `B` will resolve to `https://github.com/my-org/my-repo-B.git`, based on the value in `repositories[0].name`.

--- a/release-manager/metadata.yml.tmpl
+++ b/release-manager/metadata.yml.tmpl
@@ -17,11 +17,9 @@ services:
 
 repositories: []
 #  - id: A
-#    branch: master
 #    type: ods
 #  - id: B
 #    name: my-repo-B
-#    branch: master
 #    type: ods
 #  - id: C
 #    type: ods


### PR DESCRIPTION
Remove obsolete branch param from release-manager starter. 
The branch is now retrieved from the default branch configured for each repository.