### PR TITLE
Cypress evidence improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
 - Introduce Rust Quickstarter dependency graph linting (cargo-deny) and upgrade maintenance ([#1061](https://github.com/opendevstack/ods-quickstarters/issues/1061))
 - Add microsoft-edge to nodejs agents for using with cypress ([#1063](https://github.com/opendevstack/ods-quickstarters/pull/1063))
 - Replaced centos8 repository for AlmaLinux 8 due to deprecation ([#1063](https://github.com/opendevstack/ods-quickstarters/pull/1063))
+- Refactored e2e-cypress quickstarter code to only print logs of printTestEvidence functions to xUnit ([#1042](https://github.com/opendevstack/ods-quickstarters/issues/1042))
+- Refactored e2e-cypress quickstarter plugins file to TS ([#1065](https://github.com/opendevstack/ods-quickstarters/pull/1065))
+- Added functions for printing plain text evidences and taking screenshot evidences to e2e-cypress quickstarter ([#1065](https://github.com/opendevstack/ods-quickstarters/pull/1065))
+- Switched from \r to \n in e2e-cypress quickstarter evidences ([#1065](https://github.com/opendevstack/ods-quickstarters/pull/1065))
+- Update e2e-cypress quickstarter to upload screenshots for failing tests ([#1065](https://github.com/opendevstack/ods-quickstarters/pull/1065))
 
 ### Added
 
@@ -32,36 +37,44 @@
 ## [4.5.0] - 2024-06-06
 
 ### Added
+
 - Added nodejs22 agent and switch install of node to nodesource ([#1011](https://github.com/opendevstack/ods-quickstarters/pull/1011))
 
 ### Changed
+
 - Update Ionic Quickstarter ([#1009](https://github.com/opendevstack/ods-quickstarters/pull/1009))
 - Update Angular Quickstarter ([#1019](https://github.com/opendevstack/ods-quickstarters/pull/1019))
 
 ### Fixed
+
 - Workaround for centos 8 stream repository deprecation ([#1021](https://github.com/opendevstack/ods-quickstarters/issues/1021))
 
 ## [4.4.0] - 2024-04-22
 
 ### Added
+
 - Added secret scanning (gitleaks) in all quickstarters ([#963](https://github.com/opendevstack/ods-quickstarters/pull/963))
 
 ### Changed
+
 - Update api version in ocp templates for image, buildconfig, route and deploymentconfig ([#1072](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1072))
 - Update Makefile adding all missing agents ([#999](https://github.com/opendevstack/ods-quickstarters/pull/999))
 
 ### Fixed
+
 - jenkins agent nodejs20 can not import private keys into gpg keyring to use with helm secrets ([#1001](https://github.com/opendevstack/ods-quickstarters/issues/1001))
 
 ## [4.3.1] - 2024-02-19
 
 ### Added
+
 - Rust Quickstarter with Axum web framework simple boilerplate ([#980](https://github.com/opendevstack/ods-quickstarters/issues/980))
 - Added ETL pipeline testing QS (e2e-python) ([#985](https://github.com/opendevstack/ods-quickstarters/pull/985))
 - Added Nodejs20 agent ([#962](https://github.com/opendevstack/ods-quickstarters/issues/962))
 - Added java 21 to jdk agent, updated Springboot and Spock quickstarters ([#962](https://github.com/opendevstack/ods-quickstarters/issues/962))
 
 ### Modified
+
 - Update Streamlit and Python quickstarters and agent ([#968](https://github.com/opendevstack/ods-quickstarters/issues/968)) & ([#982](https://github.com/opendevstack/ods-quickstarters/pull/982))
 - Update gateway-Nginx quickstarter ([#983](https://github.com/opendevstack/ods-quickstarters/pull/983))
 - Remove nodejs12 form the code ([#936](https://github.com/opendevstack/ods-quickstarters/issues/936))
@@ -70,6 +83,7 @@
 - Update Angular, TypeScript, Cypress and Ionic quickstarters ([#962](https://github.com/opendevstack/ods-quickstarters/issues/962))
 
 ### Fixed
+
 - jenkins agents can not import private keys into gpg keyring to use with helm secrets ([#945](https://github.com/opendevstack/ods-quickstarters/issues/945))
 - Streamlit quickstarter build fails to import nexus host certificates into truststore ([#951](https://github.com/opendevstack/ods-quickstarters/issues/951))
 - Rust Quickstarter Jenkins Agent CICD tools with fixed versions ([#988](https://github.com/opendevstack/ods-quickstarters/issues/988))
@@ -77,11 +91,13 @@
 ## [4.3.0] - 2023-07-13
 
 ### Added
+
 - Addition of streamlit quickstarter ([#891](https://github.com/opendevstack/ods-quickstarters/issues/891))
 - Cypress Cloud integration and switch to nodejs 18 ([#935](https://github.com/opendevstack/ods-quickstarters/pull/935))
 - Provide build agent for Node.js 18 ([#794](https://github.com/opendevstack/ods-quickstarters/issues/794))
 
 ### Modified
+
 - Generate one xml report per spec and merge them later ([#898](https://github.com/opendevstack/ods-quickstarters/pull/898))
 - Removal of Centos agents ([#1209](https://github.com/opendevstack/ods-core/issues/1209))
 - Update of Python agent, Python, Streamlit and Jupyter quickstarters ([#902](https://github.com/opendevstack/ods-quickstarters/issues/902))
@@ -102,6 +118,7 @@
 - Set default rollout strategy to recreate ([#926](https://github.com/opendevstack/ods-quickstarters/issues/926))
 
 ### Fixed
+
 - Fix oauth-proxy sidecar image ([#862](https://github.com/opendevstack/ods-quickstarters/issues/862))
 - Fix Jenkinsfile params in StreamLit ([#941](https://github.com/opendevstack/ods-quickstarters/pull/941)) ([#939](https://github.com/opendevstack/ods-quickstarters/pull/939))
 - Fixed Angular build for error "Unknown argument: sourceMap" ([#940](https://github.com/opendevstack/ods-quickstarters/pull/940))
@@ -242,7 +259,7 @@
 - fix typescript-express junit test location ([#654](https://github.com/opendevstack/ods-quickstarters/issues/654))
 - fix java not in path for python quickstarter ([#685](https://github.com/opendevstack/ods-quickstarters/issues/685))
 - fix gitignore in inf-terraform ([#767](https://github.com/opendevstack/ods-quickstarters/issues/767))
-- fix e2e-spock-geb quickstarter groovy tests runs twice ([#874] https://github.com/opendevstack/ods-jenkins-shared-library/issues/874)
+- fix e2e-spock-geb quickstarter groovy tests runs twice ([#874] <https://github.com/opendevstack/ods-jenkins-shared-library/issues/874>)
 
 ### Removed
 
@@ -251,6 +268,7 @@
 ## [3.0] - 2020-08-11
 
 ### Added
+
 - Feature/add complex RM test features, and use doc downloading tests ([#404](https://github.com/opendevstack/ods-quickstarters/pull/404))
 - Quickstarters need to generate code coverage (and report to SQ) ([#213](https://github.com/opendevstack/ods-quickstarters/issues/213))
 - set nexus as default pip repo index for jenkins python agent ([#396](https://github.com/opendevstack/ods-quickstarters/issues/396))
@@ -272,6 +290,7 @@
 - Add AWS Terraform agent into makefile ([#570](https://github.com/opendevstack/ods-quickstarters/pull/570))
 
 ### Changed
+
 - Upgrade to the latest python 3.8 ([#415](https://github.com/opendevstack/ods-quickstarters/issues/415))
 - get build name dynamically from webhook proxy response ([#364](https://github.com/opendevstack/ods-quickstarters/pull/364))
 - airflow-cluster moved to extra-quickstarters ([#351](https://github.com/opendevstack/ods-quickstarters/pull/351))
@@ -298,6 +317,7 @@
 - Bump urllib by bot ([#566](https://github.com/opendevstack/ods-quickstarters/issues/566))
 
 ### Fixed
+
 - fix issue with too long names on be-typescript-express ([#378](https://github.com/opendevstack/ods-quickstarters/pull/378))
 - Latest jenkins-slave-base:v3.11 breaks jenkins-agent-maven ([#354](https://github.com/opendevstack/ods-quickstarters/issues/354))
 - fix ds components templates ([#344](https://github.com/opendevstack/ods-quickstarters/pull/344))
@@ -323,6 +343,7 @@
 - MRO / monorepo quickstarter fixes ([#233](https://github.com/opendevstack/ods-quickstarters/pull/233))
 
 ### Removed
+
 - Remove deprecated dockerImageRepository field ([#369](https://github.com/opendevstack/ods-quickstarters/pull/369))
 - Remove --watch option from npm run build command ([#341](https://github.com/opendevstack/ods-quickstarters/issues/341))
 - Remove deprecated sonar.language property ([#325](https://github.com/opendevstack/ods-quickstarters/pull/325))
@@ -332,6 +353,7 @@
 ## [2.0] - 2019-12-13
 
 ### Added
+
 - Quickstarter-specific memory quotas ([#12](https://github.com/opendevstack/ods-quickstarters/issues/12))
 - Quickstarter-specific CPU quotas ([#74](https://github.com/opendevstack/ods-quickstarters/issues/74))
 - Add 'release-manager.yml' to each quickstarter ([#53](https://github.com/opendevstack/ods-quickstarters/issues/53))
@@ -339,6 +361,7 @@
 - Add central Tailorfile to easily compare resources ([#44](https://github.com/opendevstack/ods-quickstarters/issues/44))
 
 ### Changed
+
 - Quickstarters have been renamed for more consistency when they were moved from `ods-project-quickstarters`
 - Switch to OAuth proxy in jupyter-notebook and r-shiny quickstarters ([#46](https://github.com/opendevstack/ods-quickstarters/issues/46))
 - Airflow Quickstarter fully provisioned in user's ODS project ([#60](https://github.com/opendevstack/ods-quickstarters/issues/60))
@@ -352,11 +375,13 @@
 - be-spring-boot: added springCliVersion, updated springframework to 2.2.1 ([#40](https://github.com/opendevstack/ods-quickstarters/pull/40))
 
 ### Fixed
+
 - Wrong file permission stops Snyk cli from running in Python agent ([#67](https://github.com/opendevstack/ods-quickstarters/issues/67))
 - Spring Boot quickstarter ignores property `no_nexus` ([#61](https://github.com/opendevstack/ods-quickstarters/issues/61))
 - be-typescript-express: node version in deployment image doesn't match build image ([#8](https://github.com/opendevstack/ods-quickstarters/issues/8))
 
 ### Removed
+
 - `NEXUS_HOST` param for component creation ([#70](https://github.com/opendevstack/ods-quickstarters/issues/70))
 - Remove nodejs8 agent image ([#54](https://github.com/opendevstack/ods-quickstarters/issues/54))
 
@@ -402,6 +427,7 @@
 ## [1.1.0 ods-project-quickstarters] - 2019-05-28
 
 ### Added
+
 - Rundeck `prepare-continous integration` job can now be used to upgrade an existing git repository ([#110](https://github.com/opendevstack/ods-project-quickstarters/pull/110))
 - New quickstarter `be-docker-plain`: useful for starting with a plain `Dockerfile` and no BE/FE framework on top ([#97](https://github.com/opendevstack/ods-project-quickstarters/issues/97))
 - Maven/Gradle Jenkins agent `jenkins-agent-maven` now gets Nexus credentials injected as server into `settings.xml` ([#127](https://github.com/opendevstack/ods-project-quickstarters/issues/127))
@@ -411,11 +437,13 @@
 - Documentation of all quickstarters and agents added
 
 ### Changed
+
 - Python quickstarter should use nexus as artifact repo ([#27](https://github.com/opendevstack/ods-project-quickstarters/issues/27))
 - Jupyter & R-Shiny quickstarters are now based on new Openresty-based WAF image ([#103](https://github.com/opendevstack/ods-project-quickstarters/pull/103))
 - NodeJS 10 Angular Jenkins agent `nodejs10-angular` replaces `nodejs8-angular` and supports nodeJS 10, Angular CLI 8.0.1 and cypress 3.3.1
 
 ### Fixed
+
 - Rshiny quickstarter broken - due to refactoring and webhook proxy introduction ([#200](https://github.com/opendevstack/ods-project-quickstarters/issues/200)) & ([#184](https://github.com/opendevstack/ods-project-quickstarters/issues/184))
 - Create-projects.sh seeds wrong jenkins SA rights & misses default SA for webhook proxy bug ([#189](https://github.com/opendevstack/ods-project-quickstarters/issus/189))
 - import metadata: docker pull secrets are not created in an existing project - breaks oc import-image ([#202](https://github.com/opendevstack/ods-project-quickstarters/issues/202))
@@ -424,6 +452,7 @@
 ## [1.0.2 ods-project-quickstarters] - 2019-04-02
 
 ### Fixed
+
 - Angular quickstarter `fe-angular-frontend` compilation failed due to changed dependency ([#129](https://github.com/opendevstack/ods-project-quickstarters/issues/129))
 - Spring boot quickstarter `be-springboot` gradle build failed due to dependency update to gradle 4.10 ([#131](https://github.com/opendevstack/ods-project-quickstarters/issues/131))
 - Upgrade of repo, thru rundeck job `prepare-continous integration` fails with invalid device ([#124](https://github.com/opendevstack/ods-project-quickstarters/issues/124))
@@ -432,18 +461,20 @@
 ## [1.0.1 ods-project-quickstarters] - 2019-01-25
 
 ### Fixed
+
 - Exclude images in `openshift` and `rhscl` namespace on import ([#102](https://github.com/opendevstack/ods-project-quickstarters/pull/102))
 - Maven agent fails when proxy is configured due to invalid XML ([#108](https://github.com/opendevstack/ods-project-quickstarters/pull/108))
-
 
 ## [1.0.0 ods-project-quickstarters] - 2018-12-03
 
 ### Added
+
 - Spring Boot Jenkins pipeline surfaces test results (#34)
 - Jenkins webhook proxy templates (#81, #82)
 
 ### Changed
-- Quickstarter build containers (located in the subdirs of https://github.com/opendevstack/ods-project-quickstarters/tree/master/boilerplates) inherit from corresponding Jenkins build agents now rather than replicating the setup
+
+- Quickstarter build containers (located in the subdirs of <https://github.com/opendevstack/ods-project-quickstarters/tree/master/boilerplates>) inherit from corresponding Jenkins build agents now rather than replicating the setup
 - Rundeck's OC container inherits from `jenkins-agent-base` now. The pull and tag is triggered thru *verify-rundeck-settings* rundeck job (#32)
 - The build of a quickstarter component does not upload the tarball to Nexus anymore - instead it uses binary build configs (#9)
 - The containers used to connect to openshift now pull the root ca during build, to ensure SSL trust (#12, #54)
@@ -455,14 +486,15 @@
 - Build Jupyter/Rshiny via Jenkins (#92)
 
 ### Fixed
+
 - Nodejs 8 quickstarter failed on npm run coverage (#22)
 - Rundeck containers not cleaned up (#16, #17)
 - Disable inclusion of Nginx server version in HTTP headers (#79)
 - Jupyter: install from Nexus (#65)
 
 ### Removed
-- Remove broken be-database quickstarter (#87)
 
+- Remove broken be-database quickstarter (#87)
 
 ## [0.1.0 ods-project-quickstarters] - 2018-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,7 @@
 - Introduce Rust Quickstarter dependency graph linting (cargo-deny) and upgrade maintenance ([#1061](https://github.com/opendevstack/ods-quickstarters/issues/1061))
 - Add microsoft-edge to nodejs agents for using with cypress ([#1063](https://github.com/opendevstack/ods-quickstarters/pull/1063))
 - Replaced centos8 repository for AlmaLinux 8 due to deprecation ([#1063](https://github.com/opendevstack/ods-quickstarters/pull/1063))
-- Refactored e2e-cypress quickstarter code to only print logs of printTestEvidence functions to xUnit ([#1042](https://github.com/opendevstack/ods-quickstarters/issues/1042))
-- Refactored e2e-cypress quickstarter plugins file to TS ([#1065](https://github.com/opendevstack/ods-quickstarters/pull/1065))
-- Added functions for printing plain text evidences and taking screenshot evidences to e2e-cypress quickstarter ([#1065](https://github.com/opendevstack/ods-quickstarters/pull/1065))
-- Switched from \r to \n in e2e-cypress quickstarter evidences ([#1065](https://github.com/opendevstack/ods-quickstarters/pull/1065))
-- Update e2e-cypress quickstarter to upload screenshots for failing tests ([#1065](https://github.com/opendevstack/ods-quickstarters/pull/1065))
+- Improvements in the reporter for cypress ([#1042](https://github.com/opendevstack/ods-quickstarters/issues/1042))
 
 ### Added
 
@@ -37,44 +33,36 @@
 ## [4.5.0] - 2024-06-06
 
 ### Added
-
 - Added nodejs22 agent and switch install of node to nodesource ([#1011](https://github.com/opendevstack/ods-quickstarters/pull/1011))
 
 ### Changed
-
 - Update Ionic Quickstarter ([#1009](https://github.com/opendevstack/ods-quickstarters/pull/1009))
 - Update Angular Quickstarter ([#1019](https://github.com/opendevstack/ods-quickstarters/pull/1019))
 
 ### Fixed
-
 - Workaround for centos 8 stream repository deprecation ([#1021](https://github.com/opendevstack/ods-quickstarters/issues/1021))
 
 ## [4.4.0] - 2024-04-22
 
 ### Added
-
 - Added secret scanning (gitleaks) in all quickstarters ([#963](https://github.com/opendevstack/ods-quickstarters/pull/963))
 
 ### Changed
-
 - Update api version in ocp templates for image, buildconfig, route and deploymentconfig ([#1072](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1072))
 - Update Makefile adding all missing agents ([#999](https://github.com/opendevstack/ods-quickstarters/pull/999))
 
 ### Fixed
-
 - jenkins agent nodejs20 can not import private keys into gpg keyring to use with helm secrets ([#1001](https://github.com/opendevstack/ods-quickstarters/issues/1001))
 
 ## [4.3.1] - 2024-02-19
 
 ### Added
-
 - Rust Quickstarter with Axum web framework simple boilerplate ([#980](https://github.com/opendevstack/ods-quickstarters/issues/980))
 - Added ETL pipeline testing QS (e2e-python) ([#985](https://github.com/opendevstack/ods-quickstarters/pull/985))
 - Added Nodejs20 agent ([#962](https://github.com/opendevstack/ods-quickstarters/issues/962))
 - Added java 21 to jdk agent, updated Springboot and Spock quickstarters ([#962](https://github.com/opendevstack/ods-quickstarters/issues/962))
 
 ### Modified
-
 - Update Streamlit and Python quickstarters and agent ([#968](https://github.com/opendevstack/ods-quickstarters/issues/968)) & ([#982](https://github.com/opendevstack/ods-quickstarters/pull/982))
 - Update gateway-Nginx quickstarter ([#983](https://github.com/opendevstack/ods-quickstarters/pull/983))
 - Remove nodejs12 form the code ([#936](https://github.com/opendevstack/ods-quickstarters/issues/936))
@@ -83,7 +71,6 @@
 - Update Angular, TypeScript, Cypress and Ionic quickstarters ([#962](https://github.com/opendevstack/ods-quickstarters/issues/962))
 
 ### Fixed
-
 - jenkins agents can not import private keys into gpg keyring to use with helm secrets ([#945](https://github.com/opendevstack/ods-quickstarters/issues/945))
 - Streamlit quickstarter build fails to import nexus host certificates into truststore ([#951](https://github.com/opendevstack/ods-quickstarters/issues/951))
 - Rust Quickstarter Jenkins Agent CICD tools with fixed versions ([#988](https://github.com/opendevstack/ods-quickstarters/issues/988))
@@ -91,13 +78,11 @@
 ## [4.3.0] - 2023-07-13
 
 ### Added
-
 - Addition of streamlit quickstarter ([#891](https://github.com/opendevstack/ods-quickstarters/issues/891))
 - Cypress Cloud integration and switch to nodejs 18 ([#935](https://github.com/opendevstack/ods-quickstarters/pull/935))
 - Provide build agent for Node.js 18 ([#794](https://github.com/opendevstack/ods-quickstarters/issues/794))
 
 ### Modified
-
 - Generate one xml report per spec and merge them later ([#898](https://github.com/opendevstack/ods-quickstarters/pull/898))
 - Removal of Centos agents ([#1209](https://github.com/opendevstack/ods-core/issues/1209))
 - Update of Python agent, Python, Streamlit and Jupyter quickstarters ([#902](https://github.com/opendevstack/ods-quickstarters/issues/902))
@@ -118,7 +103,6 @@
 - Set default rollout strategy to recreate ([#926](https://github.com/opendevstack/ods-quickstarters/issues/926))
 
 ### Fixed
-
 - Fix oauth-proxy sidecar image ([#862](https://github.com/opendevstack/ods-quickstarters/issues/862))
 - Fix Jenkinsfile params in StreamLit ([#941](https://github.com/opendevstack/ods-quickstarters/pull/941)) ([#939](https://github.com/opendevstack/ods-quickstarters/pull/939))
 - Fixed Angular build for error "Unknown argument: sourceMap" ([#940](https://github.com/opendevstack/ods-quickstarters/pull/940))
@@ -259,7 +243,7 @@
 - fix typescript-express junit test location ([#654](https://github.com/opendevstack/ods-quickstarters/issues/654))
 - fix java not in path for python quickstarter ([#685](https://github.com/opendevstack/ods-quickstarters/issues/685))
 - fix gitignore in inf-terraform ([#767](https://github.com/opendevstack/ods-quickstarters/issues/767))
-- fix e2e-spock-geb quickstarter groovy tests runs twice ([#874] <https://github.com/opendevstack/ods-jenkins-shared-library/issues/874>)
+- fix e2e-spock-geb quickstarter groovy tests runs twice ([#874] https://github.com/opendevstack/ods-jenkins-shared-library/issues/874)
 
 ### Removed
 
@@ -268,7 +252,6 @@
 ## [3.0] - 2020-08-11
 
 ### Added
-
 - Feature/add complex RM test features, and use doc downloading tests ([#404](https://github.com/opendevstack/ods-quickstarters/pull/404))
 - Quickstarters need to generate code coverage (and report to SQ) ([#213](https://github.com/opendevstack/ods-quickstarters/issues/213))
 - set nexus as default pip repo index for jenkins python agent ([#396](https://github.com/opendevstack/ods-quickstarters/issues/396))
@@ -290,7 +273,6 @@
 - Add AWS Terraform agent into makefile ([#570](https://github.com/opendevstack/ods-quickstarters/pull/570))
 
 ### Changed
-
 - Upgrade to the latest python 3.8 ([#415](https://github.com/opendevstack/ods-quickstarters/issues/415))
 - get build name dynamically from webhook proxy response ([#364](https://github.com/opendevstack/ods-quickstarters/pull/364))
 - airflow-cluster moved to extra-quickstarters ([#351](https://github.com/opendevstack/ods-quickstarters/pull/351))
@@ -317,7 +299,6 @@
 - Bump urllib by bot ([#566](https://github.com/opendevstack/ods-quickstarters/issues/566))
 
 ### Fixed
-
 - fix issue with too long names on be-typescript-express ([#378](https://github.com/opendevstack/ods-quickstarters/pull/378))
 - Latest jenkins-slave-base:v3.11 breaks jenkins-agent-maven ([#354](https://github.com/opendevstack/ods-quickstarters/issues/354))
 - fix ds components templates ([#344](https://github.com/opendevstack/ods-quickstarters/pull/344))
@@ -343,7 +324,6 @@
 - MRO / monorepo quickstarter fixes ([#233](https://github.com/opendevstack/ods-quickstarters/pull/233))
 
 ### Removed
-
 - Remove deprecated dockerImageRepository field ([#369](https://github.com/opendevstack/ods-quickstarters/pull/369))
 - Remove --watch option from npm run build command ([#341](https://github.com/opendevstack/ods-quickstarters/issues/341))
 - Remove deprecated sonar.language property ([#325](https://github.com/opendevstack/ods-quickstarters/pull/325))
@@ -353,7 +333,6 @@
 ## [2.0] - 2019-12-13
 
 ### Added
-
 - Quickstarter-specific memory quotas ([#12](https://github.com/opendevstack/ods-quickstarters/issues/12))
 - Quickstarter-specific CPU quotas ([#74](https://github.com/opendevstack/ods-quickstarters/issues/74))
 - Add 'release-manager.yml' to each quickstarter ([#53](https://github.com/opendevstack/ods-quickstarters/issues/53))
@@ -361,7 +340,6 @@
 - Add central Tailorfile to easily compare resources ([#44](https://github.com/opendevstack/ods-quickstarters/issues/44))
 
 ### Changed
-
 - Quickstarters have been renamed for more consistency when they were moved from `ods-project-quickstarters`
 - Switch to OAuth proxy in jupyter-notebook and r-shiny quickstarters ([#46](https://github.com/opendevstack/ods-quickstarters/issues/46))
 - Airflow Quickstarter fully provisioned in user's ODS project ([#60](https://github.com/opendevstack/ods-quickstarters/issues/60))
@@ -375,13 +353,11 @@
 - be-spring-boot: added springCliVersion, updated springframework to 2.2.1 ([#40](https://github.com/opendevstack/ods-quickstarters/pull/40))
 
 ### Fixed
-
 - Wrong file permission stops Snyk cli from running in Python agent ([#67](https://github.com/opendevstack/ods-quickstarters/issues/67))
 - Spring Boot quickstarter ignores property `no_nexus` ([#61](https://github.com/opendevstack/ods-quickstarters/issues/61))
 - be-typescript-express: node version in deployment image doesn't match build image ([#8](https://github.com/opendevstack/ods-quickstarters/issues/8))
 
 ### Removed
-
 - `NEXUS_HOST` param for component creation ([#70](https://github.com/opendevstack/ods-quickstarters/issues/70))
 - Remove nodejs8 agent image ([#54](https://github.com/opendevstack/ods-quickstarters/issues/54))
 
@@ -427,7 +403,6 @@
 ## [1.1.0 ods-project-quickstarters] - 2019-05-28
 
 ### Added
-
 - Rundeck `prepare-continous integration` job can now be used to upgrade an existing git repository ([#110](https://github.com/opendevstack/ods-project-quickstarters/pull/110))
 - New quickstarter `be-docker-plain`: useful for starting with a plain `Dockerfile` and no BE/FE framework on top ([#97](https://github.com/opendevstack/ods-project-quickstarters/issues/97))
 - Maven/Gradle Jenkins agent `jenkins-agent-maven` now gets Nexus credentials injected as server into `settings.xml` ([#127](https://github.com/opendevstack/ods-project-quickstarters/issues/127))
@@ -437,13 +412,11 @@
 - Documentation of all quickstarters and agents added
 
 ### Changed
-
 - Python quickstarter should use nexus as artifact repo ([#27](https://github.com/opendevstack/ods-project-quickstarters/issues/27))
 - Jupyter & R-Shiny quickstarters are now based on new Openresty-based WAF image ([#103](https://github.com/opendevstack/ods-project-quickstarters/pull/103))
 - NodeJS 10 Angular Jenkins agent `nodejs10-angular` replaces `nodejs8-angular` and supports nodeJS 10, Angular CLI 8.0.1 and cypress 3.3.1
 
 ### Fixed
-
 - Rshiny quickstarter broken - due to refactoring and webhook proxy introduction ([#200](https://github.com/opendevstack/ods-project-quickstarters/issues/200)) & ([#184](https://github.com/opendevstack/ods-project-quickstarters/issues/184))
 - Create-projects.sh seeds wrong jenkins SA rights & misses default SA for webhook proxy bug ([#189](https://github.com/opendevstack/ods-project-quickstarters/issus/189))
 - import metadata: docker pull secrets are not created in an existing project - breaks oc import-image ([#202](https://github.com/opendevstack/ods-project-quickstarters/issues/202))
@@ -452,7 +425,6 @@
 ## [1.0.2 ods-project-quickstarters] - 2019-04-02
 
 ### Fixed
-
 - Angular quickstarter `fe-angular-frontend` compilation failed due to changed dependency ([#129](https://github.com/opendevstack/ods-project-quickstarters/issues/129))
 - Spring boot quickstarter `be-springboot` gradle build failed due to dependency update to gradle 4.10 ([#131](https://github.com/opendevstack/ods-project-quickstarters/issues/131))
 - Upgrade of repo, thru rundeck job `prepare-continous integration` fails with invalid device ([#124](https://github.com/opendevstack/ods-project-quickstarters/issues/124))
@@ -461,20 +433,18 @@
 ## [1.0.1 ods-project-quickstarters] - 2019-01-25
 
 ### Fixed
-
 - Exclude images in `openshift` and `rhscl` namespace on import ([#102](https://github.com/opendevstack/ods-project-quickstarters/pull/102))
 - Maven agent fails when proxy is configured due to invalid XML ([#108](https://github.com/opendevstack/ods-project-quickstarters/pull/108))
+
 
 ## [1.0.0 ods-project-quickstarters] - 2018-12-03
 
 ### Added
-
 - Spring Boot Jenkins pipeline surfaces test results (#34)
 - Jenkins webhook proxy templates (#81, #82)
 
 ### Changed
-
-- Quickstarter build containers (located in the subdirs of <https://github.com/opendevstack/ods-project-quickstarters/tree/master/boilerplates>) inherit from corresponding Jenkins build agents now rather than replicating the setup
+- Quickstarter build containers (located in the subdirs of https://github.com/opendevstack/ods-project-quickstarters/tree/master/boilerplates) inherit from corresponding Jenkins build agents now rather than replicating the setup
 - Rundeck's OC container inherits from `jenkins-agent-base` now. The pull and tag is triggered thru *verify-rundeck-settings* rundeck job (#32)
 - The build of a quickstarter component does not upload the tarball to Nexus anymore - instead it uses binary build configs (#9)
 - The containers used to connect to openshift now pull the root ca during build, to ensure SSL trust (#12, #54)
@@ -486,15 +456,14 @@
 - Build Jupyter/Rshiny via Jenkins (#92)
 
 ### Fixed
-
 - Nodejs 8 quickstarter failed on npm run coverage (#22)
 - Rundeck containers not cleaned up (#16, #17)
 - Disable inclusion of Nginx server version in HTTP headers (#79)
 - Jupyter: install from Nexus (#65)
 
 ### Removed
-
 - Remove broken be-database quickstarter (#87)
+
 
 ## [0.1.0 ods-project-quickstarters] - 2018-07-27
 

--- a/docs/modules/quickstarters/pages/e2e-cypress.adoc
+++ b/docs/modules/quickstarters/pages/e2e-cypress.adoc
@@ -13,7 +13,9 @@ This is a Cypress end-to-end testing project quickstarter with basic setup for h
 ├── fixtures
 │   └── example.json
 ├── plugins
-│   └── index.js
+│   ├── index.ts
+│   ├── screenshot.ts
+│   └── screenshot.types.ts
 ├── reporters
 │   └── custom-reporter.js
 ├── support

--- a/e2e-cypress/Jenkinsfile.template
+++ b/e2e-cypress/Jenkinsfile.template
@@ -29,11 +29,23 @@ odsComponentPipeline(
     // 'release/': 'test'
   ]
 ) { context ->
-  
+  def targetDirectory = "${context.projectId}/${context.componentId}/${context.gitBranch.replaceAll('/', '-')}/${context.buildNumber}"
+
   stageTest(context)
   odsComponentStageScanWithSonar(context)
-  
+
+  if (fileExists('cypress/screenshots.zip')) {
+    odsComponentStageUploadToNexus(context,
+      [
+        distributionFile: 'cypress/screenshots.zip',
+        repository: 'leva-documentation',
+        repositoryType: 'raw',
+        targetDirectory: "${targetDirectory}"
+      ]
+    )
   }
+
+}
 
 def stageTest(def context) {
   stage('Integration Test') {
@@ -67,11 +79,13 @@ def stageTest(def context) {
       zip zipFile: 'cypress/videos.zip', archive: false, dir: 'cypress/videos'
       stash(name: "acceptance-test-videos-${context.componentId}-${context.buildNumber}", includes: 'cypress/videos.zip', allowEmpty: true)
       archiveArtifacts artifacts: 'cypress/videos.zip', fingerprint: true, daysToKeep: 2, numToKeep: 3
-      if (status != 0) {
+
+      if (fileExists('cypress/screenshots')) {
         zip zipFile: 'cypress/screenshots.zip', archive: false, dir: 'cypress/screenshots'
         stash(name: "acceptance-test-screenshots-${context.componentId}-${context.buildNumber}", includes: 'cypress/screenshots.zip', allowEmpty: true)
         archiveArtifacts artifacts: 'cypress/screenshots.zip', fingerprint: true, daysToKeep: 2, numToKeep: 3
       }
+      
       return status
     }
   }

--- a/e2e-cypress/Jenkinsfile.template
+++ b/e2e-cypress/Jenkinsfile.template
@@ -76,9 +76,12 @@ def stageTest(def context) {
       stash(name: "installation-test-reports-junit-xml-${context.componentId}-${context.buildNumber}", includes: 'build/test-results/installation-junit.xml', allowEmpty: true)
       stash(name: "integration-test-reports-junit-xml-${context.componentId}-${context.buildNumber}", includes: 'build/test-results/integration-junit.xml', allowEmpty: true)
       stash(name: "acceptance-test-reports-junit-xml-${context.componentId}-${context.buildNumber}", includes: 'build/test-results/acceptance-junit.xml', allowEmpty: true)
-      zip zipFile: 'cypress/videos.zip', archive: false, dir: 'cypress/videos'
-      stash(name: "acceptance-test-videos-${context.componentId}-${context.buildNumber}", includes: 'cypress/videos.zip', allowEmpty: true)
-      archiveArtifacts artifacts: 'cypress/videos.zip', fingerprint: true, daysToKeep: 2, numToKeep: 3
+
+      if (fileExists('cypress/videos')) {
+        zip zipFile: 'cypress/videos.zip', archive: false, dir: 'cypress/videos'
+        stash(name: "acceptance-test-videos-${context.componentId}-${context.buildNumber}", includes: 'cypress/videos.zip', allowEmpty: true)
+        archiveArtifacts artifacts: 'cypress/videos.zip', fingerprint: true, daysToKeep: 2, numToKeep: 3
+      }
 
       if (fileExists('cypress/screenshots')) {
         zip zipFile: 'cypress/screenshots.zip', archive: false, dir: 'cypress/screenshots'

--- a/e2e-cypress/Jenkinsfile.template
+++ b/e2e-cypress/Jenkinsfile.template
@@ -54,6 +54,8 @@ def stageTest(def context) {
       // "CYPRESS_CLIENT_SECRET=${azureClientSecret}",
       // "CYPRESS_USERNAME=${cypressUser}",
       // "CYPRESS_PASSWORD=${cypressPassword}"
+      "COMMIT_INFO_SHA=${context.gitCommit}",
+      "BUILD_NUMBER=${context.buildNumber}",
     ]) {
       sh 'npm install'
       def status = sh(script: 'npm run e2e', returnStatus: true)

--- a/e2e-cypress/files/cypress-acceptance.config.ts
+++ b/e2e-cypress/files/cypress-acceptance.config.ts
@@ -16,8 +16,8 @@ export default defineConfig({
     viewportHeight: 660,
     experimentalModifyObstructiveThirdPartyCode:true,
     video: true,
-    setupNodeEvents(on, config) {
-      return require('./plugins/index.js')(on, config)
+    async setupNodeEvents(on, config) {
+      return (await import('./plugins/index')).default(on, config);
     },
   },
 })

--- a/e2e-cypress/files/cypress-installation.config.ts
+++ b/e2e-cypress/files/cypress-installation.config.ts
@@ -16,8 +16,8 @@ export default defineConfig({
     viewportHeight: 660,
     experimentalModifyObstructiveThirdPartyCode:true,
     video: true,
-    setupNodeEvents(on, config) {
-      return require('./plugins/index.js')(on, config)
+    async setupNodeEvents(on, config) {
+      return (await import('./plugins/index')).default(on, config);
     },
   },
 })

--- a/e2e-cypress/files/cypress-integration.config.ts
+++ b/e2e-cypress/files/cypress-integration.config.ts
@@ -16,8 +16,8 @@ export default defineConfig({
     viewportHeight: 660,
     experimentalModifyObstructiveThirdPartyCode:true,
     video: true,
-    setupNodeEvents(on, config) {
-      return require('./plugins/index.js')(on, config)
+    async setupNodeEvents(on, config) {
+      return (await import('./plugins/index')).default(on, config);
     },
   },
 })

--- a/e2e-cypress/files/cypress.config.ts
+++ b/e2e-cypress/files/cypress.config.ts
@@ -15,8 +15,8 @@ export default defineConfig({
     viewportHeight: 660,
     experimentalModifyObstructiveThirdPartyCode: true,
     video: true,
-    setupNodeEvents(on, config) {
-      return require('./plugins/index.js')(on, config)
+    async setupNodeEvents(on, config) {
+      return (await import('./plugins/index')).default(on, config);
     },
   },
 })

--- a/e2e-cypress/files/package.json
+++ b/e2e-cypress/files/package.json
@@ -25,6 +25,7 @@
     "mocha-junit-reporter": "^2.2.1",
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.0.1",
+    "sharp": "^0.33.5",
     "typescript": "^5.5.4"
   }
 }

--- a/e2e-cypress/files/plugins/index.ts
+++ b/e2e-cypress/files/plugins/index.ts
@@ -11,7 +11,7 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-module.exports = (on, config) => {
+const setupNodeEvents: NonNullable<Cypress.ConfigOptions['setupNodeEvents']> = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
   on('task', {
@@ -21,3 +21,5 @@ module.exports = (on, config) => {
     },
   });
 };
+
+export default setupNodeEvents;

--- a/e2e-cypress/files/plugins/index.ts
+++ b/e2e-cypress/files/plugins/index.ts
@@ -8,6 +8,9 @@
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
 
+import type { ScreenshotEvidenceData } from './screenshot';
+import { addEvidenceMetaToScreenshot } from './screenshot';
+
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
@@ -19,6 +22,9 @@ const setupNodeEvents: NonNullable<Cypress.ConfigOptions['setupNodeEvents']> = (
       console.log(message);
       return null;
     },
+    async takeScreenshotEvidence(data: ScreenshotEvidenceData) {
+      return await addEvidenceMetaToScreenshot(data);
+    }
   });
 };
 

--- a/e2e-cypress/files/plugins/index.ts
+++ b/e2e-cypress/files/plugins/index.ts
@@ -8,7 +8,7 @@
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
 
-import type { ScreenshotEvidenceData } from './screenshot';
+import type { ScreenshotEvidenceData } from './screenshot.types';
 import { addEvidenceMetaToScreenshot } from './screenshot';
 
 // This function is called when a project is opened or re-opened (e.g. due to

--- a/e2e-cypress/files/plugins/screenshot.ts
+++ b/e2e-cypress/files/plugins/screenshot.ts
@@ -1,28 +1,7 @@
 import { createHash } from 'crypto';
 import { writeFile } from 'fs/promises';
-import sharp from 'sharp';
-
-export type ScreenshotEvidenceData = {
-  name: string;
-  path: string;
-  step: number;
-  subStep: number;
-  takenAt: string;
-};
-
-export type ScreenshotEvidenceResult = {
-  hash: string;
-  path: string;
-};
-export const isScreenshotEvidenceResult = (candidate: unknown): candidate is ScreenshotEvidenceResult =>
-  Boolean(
-    typeof candidate === 'object' &&
-      candidate &&
-      'hash' in candidate &&
-      'path' in candidate &&
-      typeof candidate.hash === 'string' &&
-      typeof candidate.path === 'string'
-  );
+import * as sharp from 'sharp';
+import { ScreenshotEvidenceData, ScreenshotEvidenceResult } from './screenshot.types';
 
 const SCREENSHOT_METADATA = {
   height: 50,

--- a/e2e-cypress/files/plugins/screenshot.ts
+++ b/e2e-cypress/files/plugins/screenshot.ts
@@ -1,0 +1,82 @@
+import { createHash } from 'crypto';
+import { writeFile } from 'fs/promises';
+import sharp from 'sharp';
+
+export type ScreenshotEvidenceData = {
+  name: string;
+  path: string;
+  step: number;
+  subStep: number;
+  takenAt: string;
+};
+
+export type ScreenshotEvidenceResult = {
+  hash: string;
+  path: string;
+};
+export const isScreenshotEvidenceResult = (candidate: unknown): candidate is ScreenshotEvidenceResult =>
+  Boolean(
+    typeof candidate === 'object' &&
+      candidate &&
+      'hash' in candidate &&
+      'path' in candidate &&
+      typeof candidate.hash === 'string' &&
+      typeof candidate.path === 'string'
+  );
+
+const SCREENSHOT_METADATA = {
+  height: 50,
+  margin: 10,
+  textAlign: 'left',
+  textColor: '#000',
+  textSize: 'large',
+  backgroundColor: '#fff',
+  maxNameLength: 100,
+} as const;
+const EVIDENCE_HASH_ALGORITHM = 'sha256' as const;
+
+export const addEvidenceMetaToScreenshot = async (data: ScreenshotEvidenceData): Promise<ScreenshotEvidenceResult> => {
+  const metadata: [string, string][] = [
+    ['Timestamp', data.takenAt],
+    ['Testname', data.name.substring(0, SCREENSHOT_METADATA.maxNameLength)],
+    ['Step', data.step.toString()],
+    ['Screenshot', data.subStep.toString()],
+    ['Build number', process.env.BUILD_NUMBER ?? '-'],
+    ['Git commit', process.env.COMMIT_INFO_SHA ?? '-'],
+  ];
+
+  const image = sharp(data.path);
+  const imageMetadata = await image.metadata();
+  const imageBuffer = await image
+    .resize({
+      background: SCREENSHOT_METADATA.backgroundColor,
+      fit: 'contain',
+      height: (imageMetadata.height ?? 0) + SCREENSHOT_METADATA.height,
+      position: 'bottom',
+      width: imageMetadata.width ?? 0,
+    })
+    .composite([
+      {
+        input: {
+          text: {
+            align: SCREENSHOT_METADATA.textAlign,
+            rgba: true,
+            text: metadata
+              .map(([key, value]) => `<span foreground="${SCREENSHOT_METADATA.textColor}" size="${SCREENSHOT_METADATA.textSize}"><b>${key}</b>: ${value}</span>`)
+              .join('\t'),
+            width: (imageMetadata.width ?? 0) - SCREENSHOT_METADATA.margin * 2,
+          },
+        },
+        left: SCREENSHOT_METADATA.margin,
+        top: SCREENSHOT_METADATA.margin,
+      },
+    ])
+    .toBuffer();
+  await writeFile(data.path, imageBuffer);
+
+  const hash = createHash(EVIDENCE_HASH_ALGORITHM).update(imageBuffer).digest('hex');
+  return {
+    hash,
+    path: data.path,
+  }
+};

--- a/e2e-cypress/files/plugins/screenshot.types.ts
+++ b/e2e-cypress/files/plugins/screenshot.types.ts
@@ -1,0 +1,21 @@
+export type ScreenshotEvidenceData = {
+  name: string;
+  path: string;
+  step: number;
+  subStep: number;
+  takenAt: string;
+};
+
+export type ScreenshotEvidenceResult = {
+  hash: string;
+  path: string;
+};
+export const isScreenshotEvidenceResult = (candidate: unknown): candidate is ScreenshotEvidenceResult =>
+  Boolean(
+    typeof candidate === 'object' &&
+      candidate &&
+      'hash' in candidate &&
+      'path' in candidate &&
+      typeof candidate.hash === 'string' &&
+      typeof candidate.path === 'string'
+  );

--- a/e2e-cypress/files/support/e2e.ts
+++ b/e2e-cypress/files/support/e2e.ts
@@ -68,17 +68,10 @@ Cypress.Commands.add('loginToAAD', (username: string, password: string) => {
   log.end()
 })
 
-let consoleLogs: string[] = []
-
-Cypress.on('log:added', (options) => {
-  const message = options.message;
-  if(message) {
-    consoleLogs.push(message);
-  }
-});
+export const consoleLogs: string[] = [];
 
 beforeEach(function() {
-  consoleLogs = [];
+  consoleLogs.splice(0);
 })
 
 afterEach(function() {
@@ -88,5 +81,5 @@ afterEach(function() {
 
   cy.writeFile(filePath, consoleLogs.join('\n'));
 
-  consoleLogs = [];
+  consoleLogs.splice(0);
 })

--- a/e2e-cypress/files/support/test-evidence.ts
+++ b/e2e-cypress/files/support/test-evidence.ts
@@ -2,23 +2,27 @@ import * as path from 'path';
 import { isScreenshotEvidenceResult, ScreenshotEvidenceData } from "../plugins/screenshot.types";
 import { consoleLogs } from "./e2e";
 
+const logEvidence = (name: string, step: number, description: string, evidenceLogs: string[]) => {
+  cy.url().then(url => {
+    const logs: string[] = [];
+    logs.push('=====================================');
+    logs.push(`Testname: ${name} // step: ${step}`);
+    logs.push(`URL: ${url}`);
+    logs.push(`Description: ${description}`);
+    logs.push('----- Test Evidence starts here ----');
+    logs.push(...evidenceLogs);
+    logs.push('----- Test Evidence ends here ----');
+    consoleLogs.push(...logs);
+    cy.task('log', logs.join('\n'));
+  });
+}
+
 export const printTestDOMEvidence = (testName: string, testStep: number, selector: string, description: string) => {
   if (!selector) {
     throw new Error('selector must not NOT be undefined');
   }
-  cy.url().then(urlString => {
-    cy.get(selector).then($selectedElement => {
-      const logs: string[] = [];
-      logs.push('=====================================');
-      logs.push('Testname: ' + testName + ' // step: ' + testStep);
-      logs.push('URL: ' + urlString);
-      logs.push('Description: ' + description);
-      logs.push('----- Test Evidence starts here ----');
-      logs.push('Selector: ' + selector + '\n ' + $selectedElement.get(0).outerHTML);
-      logs.push('----- Test Evidence ends here ----');
-      consoleLogs.push(...logs);
-      cy.task('log', logs.join('\n'));
-    });
+  cy.get(selector).then($selectedElement => {
+    logEvidence(testName, testStep, description, [`Selector: ${selector}\n ${$selectedElement.get(0).outerHTML}`]);
   });
 };
 
@@ -26,19 +30,10 @@ export const printTestPlainEvidence = (testName: string, testStep: number, expec
   if (!expectedValue || !actualValue) {
     throw new Error('expectedValue and actualValue must not NOT be undefined');
   }
-  cy.url().then(urlString => {
-    const logs: string[] = [];
-    logs.push('=====================================');
-    logs.push('Testname: ' + testName + ' // step: ' + testStep);
-    logs.push('URL: ' + urlString);
-    logs.push('Description: ' + description);
-    logs.push('----- Test Evidence starts here ----');
-    logs.push(`Expected Result:\n ${String(expectedValue)}`);
-    logs.push(`Actual Result:\n ${String(actualValue)}`);
-    logs.push('----- Test Evidence ends here ----');
-    consoleLogs.push(...logs);
-    cy.task('log', logs.join('\n'));
-  });
+  logEvidence(testName, testStep, description, [
+    `Expected Result:\n ${String(expectedValue)}`,
+    `Actual Result:\n ${String(actualValue)}`
+  ]);
 };
 
 export const takeScreenshotEvidence = (testName: string, testStep: number, testSubStep: number = 1, description: string, skipMeta = false) => {
@@ -67,20 +62,9 @@ export const takeScreenshotEvidence = (testName: string, testStep: number, testS
           return null;
         }
 
-        cy.url().then(urlString => {
-          const logs: string[] = [];
-          logs.push('=====================================');
-          logs.push('Testname: ' + testName + ' // step: ' + testStep);
-          logs.push('URL: ' + urlString);
-          logs.push('Description: ' + description);
-          logs.push('----- Test Evidence starts here ----');
-          logs.push(
-            `Stored screenshot "${path.basename(result.path)}" with hash (sha256) ${result.hash} taken at ${String(data.takenAt)} as evidence.`
-          );
-          logs.push('----- Test Evidence ends here ----');
-          consoleLogs.push(...logs);
-          cy.task('log', logs.join('\n'));
-        });
+        logEvidence(testName, testStep, description, [
+          `Stored screenshot "${path.basename(result.path)}" with hash (sha256) ${result.hash} taken at ${String(data.takenAt)} as evidence.`
+        ]);
       });
   });
 };

--- a/e2e-cypress/files/support/test-evidence.ts
+++ b/e2e-cypress/files/support/test-evidence.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+import { isScreenshotEvidenceResult, ScreenshotEvidenceData } from "../plugins/screenshot";
 import { consoleLogs } from "./e2e";
 
 export const printTestEvidence = (testName: string, testStep: number, selector: string, description: string) => {
@@ -18,4 +20,48 @@ export const printTestEvidence = (testName: string, testStep: number, selector: 
   logs.push('----- Test Evidence ends here ----');
   consoleLogs.push(...logs);
   cy.task('log', logs.join('\n'));
+};
+
+export const takeScreenshotEvidence = (testName: string, testStep: number, testSubStep: number = 1, description: string, skipMeta = false) => {
+  cy.wrap(null).then(() => {
+    const data: Omit<ScreenshotEvidenceData, 'path' | 'takenAt'> &
+      Partial<Pick<ScreenshotEvidenceData, 'path' | 'takenAt'>> = {
+      name: testName,
+      step: testStep,
+      subStep: testSubStep,
+    };
+
+    cy.screenshot(`testevidence_${testName}_${testStep}_${testSubStep}`, {
+      onAfterScreenshot(_, { path, takenAt }) {
+        data.path = path;
+        data.takenAt = new Date(takenAt).toISOString();
+      },
+    })
+      .then<unknown>(() => {
+        if (!data.path || !data.takenAt || skipMeta) {
+          return null;
+        }
+        cy.task('takeScreenshotEvidence', data);
+      })
+      .then((result) => {
+        if (!isScreenshotEvidenceResult(result)) {
+          return null;
+        }
+
+        const logs: string[] = [];
+        logs.push('=====================================');
+        logs.push('Testname: ' + testName + ' // step: ' + testStep);
+        cy.url().then(urlString => {
+          logs.push('URL: ' + urlString);
+        });
+        logs.push('Description: ' + description);
+        logs.push('----- Test Evidence starts here ----');
+        logs.push(
+          `Stored screenshot "${path.basename(result.path)}" with hash (sha256) ${result.hash} taken at ${String(data.takenAt)} as evidence.`
+        );
+        logs.push('----- Test Evidence ends here ----');
+        consoleLogs.push(...logs);
+        cy.task('log', logs.join('\n'));
+      });
+  });
 };

--- a/e2e-cypress/files/support/test-evidence.ts
+++ b/e2e-cypress/files/support/test-evidence.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { isScreenshotEvidenceResult, ScreenshotEvidenceData } from "../plugins/screenshot";
+import * as path from 'path';
+import { isScreenshotEvidenceResult, ScreenshotEvidenceData } from "../plugins/screenshot.types";
 import { consoleLogs } from "./e2e";
 
 export const printTestDOMEvidence = (testName: string, testStep: number, selector: string, description: string) => {

--- a/e2e-cypress/files/support/test-evidence.ts
+++ b/e2e-cypress/files/support/test-evidence.ts
@@ -1,16 +1,21 @@
+import { consoleLogs } from "./e2e";
+
 export const printTestEvidence = (testName: string, testStep: number, selector: string, description: string) => {
   if (!selector) {
     throw new Error('selector must not NOT be undefined');
   }
-  cy.task('log', '=====================================');
-  cy.task('log', 'Testname: ' + testName + ' // step: ' + testStep);
+  const logs: string[] = [];
+  logs.push('=====================================');
+  logs.push('Testname: ' + testName + ' // step: ' + testStep);
   cy.url().then(urlString => {
-    cy.task('log', 'URL: ' + urlString);
+    logs.push('URL: ' + urlString);
   });
-  cy.task('log', 'Description: ' + description);
-  cy.task('log', '----- Test Evidence starts here ----');
+  logs.push('Description: ' + description);
+  logs.push('----- Test Evidence starts here ----');
   cy.get(selector).then($selectedElement => {
-    cy.task('log', 'Selector: ' + selector + '\r ' + $selectedElement.get(0).outerHTML);
+    logs.push('Selector: ' + selector + '\r ' + $selectedElement.get(0).outerHTML);
   });
-  cy.task('log', '----- Test Evidence ends here ----');
+  logs.push('----- Test Evidence ends here ----');
+  consoleLogs.push(...logs);
+  cy.task('log', logs.join('\n'));
 };

--- a/e2e-cypress/files/support/test-evidence.ts
+++ b/e2e-cypress/files/support/test-evidence.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { isScreenshotEvidenceResult, ScreenshotEvidenceData } from "../plugins/screenshot";
 import { consoleLogs } from "./e2e";
 
-export const printTestEvidence = (testName: string, testStep: number, selector: string, description: string) => {
+export const printTestDOMEvidence = (testName: string, testStep: number, selector: string, description: string) => {
   if (!selector) {
     throw new Error('selector must not NOT be undefined');
   }
@@ -17,6 +17,25 @@ export const printTestEvidence = (testName: string, testStep: number, selector: 
   cy.get(selector).then($selectedElement => {
     logs.push('Selector: ' + selector + '\r ' + $selectedElement.get(0).outerHTML);
   });
+  logs.push('----- Test Evidence ends here ----');
+  consoleLogs.push(...logs);
+  cy.task('log', logs.join('\n'));
+};
+
+export const printTestPlainEvidence = (testName: string, testStep: number, expectedValue: string, actualValue: string, description: string) => {
+  if (!expectedValue || !actualValue) {
+    throw new Error('expectedValue and actualValue must not NOT be undefined');
+  }
+  const logs: string[] = [];
+  logs.push('=====================================');
+  logs.push('Testname: ' + testName + ' // step: ' + testStep);
+  cy.url().then(urlString => {
+    logs.push('URL: ' + urlString);
+  });
+  logs.push('Description: ' + description);
+  logs.push('----- Test Evidence starts here ----');
+  logs.push(`Expected Result:\r ${String(expectedValue)}`);
+  logs.push(`Actual Result:\r ${String(actualValue)}`);
   logs.push('----- Test Evidence ends here ----');
   consoleLogs.push(...logs);
   cy.task('log', logs.join('\n'));

--- a/e2e-cypress/files/support/test-evidence.ts
+++ b/e2e-cypress/files/support/test-evidence.ts
@@ -6,39 +6,39 @@ export const printTestDOMEvidence = (testName: string, testStep: number, selecto
   if (!selector) {
     throw new Error('selector must not NOT be undefined');
   }
-  const logs: string[] = [];
-  logs.push('=====================================');
-  logs.push('Testname: ' + testName + ' // step: ' + testStep);
   cy.url().then(urlString => {
-    logs.push('URL: ' + urlString);
+    cy.get(selector).then($selectedElement => {
+      const logs: string[] = [];
+      logs.push('=====================================');
+      logs.push('Testname: ' + testName + ' // step: ' + testStep);
+      logs.push('URL: ' + urlString);
+      logs.push('Description: ' + description);
+      logs.push('----- Test Evidence starts here ----');
+      logs.push('Selector: ' + selector + '\n ' + $selectedElement.get(0).outerHTML);
+      logs.push('----- Test Evidence ends here ----');
+      consoleLogs.push(...logs);
+      cy.task('log', logs.join('\n'));
+    });
   });
-  logs.push('Description: ' + description);
-  logs.push('----- Test Evidence starts here ----');
-  cy.get(selector).then($selectedElement => {
-    logs.push('Selector: ' + selector + '\n ' + $selectedElement.get(0).outerHTML);
-  });
-  logs.push('----- Test Evidence ends here ----');
-  consoleLogs.push(...logs);
-  cy.task('log', logs.join('\n'));
 };
 
 export const printTestPlainEvidence = (testName: string, testStep: number, expectedValue: string, actualValue: string, description: string) => {
   if (!expectedValue || !actualValue) {
     throw new Error('expectedValue and actualValue must not NOT be undefined');
   }
-  const logs: string[] = [];
-  logs.push('=====================================');
-  logs.push('Testname: ' + testName + ' // step: ' + testStep);
   cy.url().then(urlString => {
+    const logs: string[] = [];
+    logs.push('=====================================');
+    logs.push('Testname: ' + testName + ' // step: ' + testStep);
     logs.push('URL: ' + urlString);
+    logs.push('Description: ' + description);
+    logs.push('----- Test Evidence starts here ----');
+    logs.push(`Expected Result:\n ${String(expectedValue)}`);
+    logs.push(`Actual Result:\n ${String(actualValue)}`);
+    logs.push('----- Test Evidence ends here ----');
+    consoleLogs.push(...logs);
+    cy.task('log', logs.join('\n'));
   });
-  logs.push('Description: ' + description);
-  logs.push('----- Test Evidence starts here ----');
-  logs.push(`Expected Result:\n ${String(expectedValue)}`);
-  logs.push(`Actual Result:\n ${String(actualValue)}`);
-  logs.push('----- Test Evidence ends here ----');
-  consoleLogs.push(...logs);
-  cy.task('log', logs.join('\n'));
 };
 
 export const takeScreenshotEvidence = (testName: string, testStep: number, testSubStep: number = 1, description: string, skipMeta = false) => {
@@ -67,20 +67,20 @@ export const takeScreenshotEvidence = (testName: string, testStep: number, testS
           return null;
         }
 
-        const logs: string[] = [];
-        logs.push('=====================================');
-        logs.push('Testname: ' + testName + ' // step: ' + testStep);
         cy.url().then(urlString => {
+          const logs: string[] = [];
+          logs.push('=====================================');
+          logs.push('Testname: ' + testName + ' // step: ' + testStep);
           logs.push('URL: ' + urlString);
+          logs.push('Description: ' + description);
+          logs.push('----- Test Evidence starts here ----');
+          logs.push(
+            `Stored screenshot "${path.basename(result.path)}" with hash (sha256) ${result.hash} taken at ${String(data.takenAt)} as evidence.`
+          );
+          logs.push('----- Test Evidence ends here ----');
+          consoleLogs.push(...logs);
+          cy.task('log', logs.join('\n'));
         });
-        logs.push('Description: ' + description);
-        logs.push('----- Test Evidence starts here ----');
-        logs.push(
-          `Stored screenshot "${path.basename(result.path)}" with hash (sha256) ${result.hash} taken at ${String(data.takenAt)} as evidence.`
-        );
-        logs.push('----- Test Evidence ends here ----');
-        consoleLogs.push(...logs);
-        cy.task('log', logs.join('\n'));
       });
   });
 };

--- a/e2e-cypress/files/support/test-evidence.ts
+++ b/e2e-cypress/files/support/test-evidence.ts
@@ -15,7 +15,7 @@ export const printTestDOMEvidence = (testName: string, testStep: number, selecto
   logs.push('Description: ' + description);
   logs.push('----- Test Evidence starts here ----');
   cy.get(selector).then($selectedElement => {
-    logs.push('Selector: ' + selector + '\r ' + $selectedElement.get(0).outerHTML);
+    logs.push('Selector: ' + selector + '\n ' + $selectedElement.get(0).outerHTML);
   });
   logs.push('----- Test Evidence ends here ----');
   consoleLogs.push(...logs);
@@ -34,8 +34,8 @@ export const printTestPlainEvidence = (testName: string, testStep: number, expec
   });
   logs.push('Description: ' + description);
   logs.push('----- Test Evidence starts here ----');
-  logs.push(`Expected Result:\r ${String(expectedValue)}`);
-  logs.push(`Actual Result:\r ${String(actualValue)}`);
+  logs.push(`Expected Result:\n ${String(expectedValue)}`);
+  logs.push(`Actual Result:\n ${String(actualValue)}`);
   logs.push('----- Test Evidence ends here ----');
   consoleLogs.push(...logs);
   cy.task('log', logs.join('\n'));

--- a/e2e-cypress/files/tests/acceptance/acceptance.spec.cy.ts
+++ b/e2e-cypress/files/tests/acceptance/acceptance.spec.cy.ts
@@ -1,4 +1,4 @@
-import { printTestEvidence } from '../../support/test-evidence';
+import { printTestEvidence, takeScreenshotEvidence } from '../../support/test-evidence';
 
 /* tslint:disable:no-unused-expression */
 // describe('ADD login example test', () => {
@@ -21,5 +21,7 @@ describe('W3 application test', () => {
     cy.title().should('include', 'Tryit Editor');
     printTestEvidence(this.test.fullTitle(), 1, '#textareaCode', 'code area');
     printTestEvidence(this.test.fullTitle(), 2, '#iframecontainer', 'rendered code area');
+    takeScreenshotEvidence(this.test.fullTitle(), 3, 1, 'screenshot');
+    takeScreenshotEvidence(this.test.fullTitle(), 3, 2, 'screenshot substep 2');
   });
 });

--- a/e2e-cypress/files/tests/acceptance/acceptance.spec.cy.ts
+++ b/e2e-cypress/files/tests/acceptance/acceptance.spec.cy.ts
@@ -1,4 +1,4 @@
-import { printTestEvidence, takeScreenshotEvidence } from '../../support/test-evidence';
+import { printTestDOMEvidence, printTestPlainEvidence, takeScreenshotEvidence } from '../../support/test-evidence';
 
 /* tslint:disable:no-unused-expression */
 // describe('ADD login example test', () => {
@@ -19,9 +19,12 @@ describe('W3 application test', () => {
   it('Application is reachable', function () {
     cy.visit('/html/tryit.asp?filename=tryhtml_basic_paragraphs');
     cy.title().should('include', 'Tryit Editor');
-    printTestEvidence(this.test.fullTitle(), 1, '#textareaCode', 'code area');
-    printTestEvidence(this.test.fullTitle(), 2, '#iframecontainer', 'rendered code area');
+    printTestDOMEvidence(this.test.fullTitle(), 1, '#textareaCode', 'code area');
+    printTestDOMEvidence(this.test.fullTitle(), 2, '#iframecontainer', 'rendered code area');
     takeScreenshotEvidence(this.test.fullTitle(), 3, 1, 'screenshot');
     takeScreenshotEvidence(this.test.fullTitle(), 3, 2, 'screenshot substep 2');
+    cy.title().then(title => {
+      printTestPlainEvidence(this.test.fullTitle(), 4, title, 'Tryit Editor', 'Title should include Tryit Editor');
+    });
   });
 });


### PR DESCRIPTION
Improves the test evidences for the e2e-cypress quickstarter by:

- only adding log lines related to the test evidences to the xUnit files. (4f5c1c636a236282bcfc9ed053bce01721dbfcb4)
- switching plugin file to TS (5b9ddcbcd62f47376e00a604a5274788f4befe39)
- Add functions for printing plain text evidences and taking screenshot evidences (30edc9d8b3c1a27b800f78c4a289a216962f71fe, 5c1e480378c470625d6e45a2d508e9d0abce739a and some fixes afterwards)

Closes #1042

Tasks: 
- [x] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
