### PR TITLE
Fix Rust quickstarter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Changed
 
 ### Fixed
+- Fixed Rust Quickstarter provisioning issues ([#1097](https://github.com/opendevstack/ods-quickstarters/pull/1097))
+
 
 ## [4.7.0] - 2025-1-27
 

--- a/be-rust-axum/Jenkinsfile
+++ b/be-rust-axum/Jenkinsfile
@@ -21,11 +21,11 @@ odsQuickstarterPipeline(
   // https://cargo-generate.github.io/cargo-generate/index.html
   stage('Cargo Generate project') {
     sh(
-      script: "cargo generate --path ${context.sourceDir}/rust-template --name ${context.componentId}",
+      script: "cargo generate --path ${context.sourceDir}/rust-template --name ${context.componentId} --destination /tmp",
       label: "Process Rust template"
     )
     sh(
-      script: "mv ${context.componentId} ${context.sourceDir}/files",
+      script: "mv /tmp/${context.componentId} ${context.sourceDir}/files",
       label: "Create files folder"
     )
   }

--- a/be-rust-axum/Jenkinsfile
+++ b/be-rust-axum/Jenkinsfile
@@ -21,13 +21,13 @@ odsQuickstarterPipeline(
   // https://cargo-generate.github.io/cargo-generate/index.html
   stage('Cargo Generate project') {
     sh(
-      script: "mkdir ${context.sourceDir}/files && cargo generate --path ${context.sourceDir}/rust-template --name ${context.componentId} --destination ${context.sourceDir}/files",
+      script: "mkdir ${context.sourceDir}/tmp && cargo generate --path ${context.sourceDir}/rust-template --name ${context.componentId} --destination ${context.sourceDir}/tmp",
       label: "Process Rust template"
     )
-    // sh(
-    //   script: "mv /tmp/${context.componentId} ${context.sourceDir}/files",
-    //   label: "Create files folder"
-    // )
+    sh(
+      script: "mv ${context.sourceDir}/tmp/${context.componentId} ${context.sourceDir}/files",
+      label: "Create files folder"
+    )
   }
 
   odsQuickstarterStageCopyFiles(context)

--- a/be-rust-axum/Jenkinsfile
+++ b/be-rust-axum/Jenkinsfile
@@ -21,11 +21,11 @@ odsQuickstarterPipeline(
   // https://cargo-generate.github.io/cargo-generate/index.html
   stage('Cargo Generate project') {
     sh(
-      script: "cargo generate --path ${context.sourceDir}/rust-template --name ${context.componentId} --destination ${context.sourceDir}/tempdir",
-      label: "Process Rust template to tempdir"
+      script: "cargo generate --path ${context.sourceDir}/rust-template --name ${context.projectId}-${context.componentId}",
+      label: "Process Rust template"
     )
-      sh(
-      script: "mv ${context.sourceDir}/tempdir/${context.componentId} ${context.sourceDir}/files",
+    sh(
+      script: "mv ${context.projectId}-${context.componentId} ${context.sourceDir}/files",
       label: "Create files folder"
     )
   }

--- a/be-rust-axum/Jenkinsfile
+++ b/be-rust-axum/Jenkinsfile
@@ -21,11 +21,11 @@ odsQuickstarterPipeline(
   // https://cargo-generate.github.io/cargo-generate/index.html
   stage('Cargo Generate project') {
     sh(
-      script: "cargo generate --path ${context.sourceDir}/rust-template --name ${context.projectId}-${context.componentId}",
+      script: "cargo generate --path ${context.sourceDir}/rust-template --name ${context.componentId}",
       label: "Process Rust template"
     )
     sh(
-      script: "mv ${context.projectId}-${context.componentId} ${context.sourceDir}/files",
+      script: "mv ${context.componentId} ${context.sourceDir}/files",
       label: "Create files folder"
     )
   }

--- a/be-rust-axum/Jenkinsfile
+++ b/be-rust-axum/Jenkinsfile
@@ -21,13 +21,13 @@ odsQuickstarterPipeline(
   // https://cargo-generate.github.io/cargo-generate/index.html
   stage('Cargo Generate project') {
     sh(
-      script: "cargo generate --path ${context.sourceDir}/rust-template --name ${context.componentId} --destination /tmp",
+      script: "cargo generate --path ${context.sourceDir}/rust-template --name ${context.componentId} --destination ${context.sourceDir}/files",
       label: "Process Rust template"
     )
-    sh(
-      script: "mv /tmp/${context.componentId} ${context.sourceDir}/files",
-      label: "Create files folder"
-    )
+    // sh(
+    //   script: "mv /tmp/${context.componentId} ${context.sourceDir}/files",
+    //   label: "Create files folder"
+    // )
   }
 
   odsQuickstarterStageCopyFiles(context)

--- a/be-rust-axum/Jenkinsfile
+++ b/be-rust-axum/Jenkinsfile
@@ -21,7 +21,7 @@ odsQuickstarterPipeline(
   // https://cargo-generate.github.io/cargo-generate/index.html
   stage('Cargo Generate project') {
     sh(
-      script: "cargo generate --path ${context.sourceDir}/rust-template --name ${context.componentId} --destination ${context.sourceDir}/files",
+      script: "mkdir ${context.sourceDir}/files && cargo generate --path ${context.sourceDir}/rust-template --name ${context.componentId} --destination ${context.sourceDir}/files",
       label: "Process Rust template"
     )
     // sh(

--- a/be-rust-axum/Jenkinsfile.template
+++ b/be-rust-axum/Jenkinsfile.template
@@ -23,7 +23,7 @@ odsComponentPipeline(
 def stageBuild(def context) {
   stage('Cargo Build') {
     sh "cargo build --release"
-    sh "cp -r target/release/${context.projectId}-${context.componentId} docker/app"
+    sh "cp -r target/release/${context.componentId} docker/app"
   }
 }
 

--- a/be-rust-axum/Jenkinsfile.template
+++ b/be-rust-axum/Jenkinsfile.template
@@ -23,7 +23,7 @@ odsComponentPipeline(
 def stageBuild(def context) {
   stage('Cargo Build') {
     sh "cargo build --release"
-    sh "cp -r target/release/${context.componentId} docker/app"
+    sh "cp -r target/release/${context.projectId}-${context.componentId} docker/app"
   }
 }
 


### PR DESCRIPTION
Fix Rust Quickstarter after last merge to 4.x. Issues arises due to fixing the merge conflicts

Test:

- [x] Provisioning pipeline
- [x] Component pipeline
- [x] Orchestration pipeline (up to QA)