### PR TITLE
e2e-cypress: get rid of additional chrome installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Set Request and Limits with Ephemeral storage and Make use of Nexus in terraform agents ([#1104](https://github.com/opendevstack/ods-quickstarters/pull/1104))
 - Fix ds-streamlit uses old CI colors ([#978](https://github.com/opendevstack/ods-quickstarters/issues/978))
 - Remove unnecessary evidence printing in e2e-spock-geb ([#1106](https://github.com/opendevstack/ods-quickstarters/pull/1106))
+- e2e-cypress get rid of additional chrome installation and switch to edge for pdf generation
 
 ### Fixed
 

--- a/e2e-cypress/files/package.json
+++ b/e2e-cypress/files/package.json
@@ -30,7 +30,7 @@
     "mochawesome": "^7.1.3",
     "npm-run-all": "^4.1.5",
     "otplib": "^12.0.1",
-    "puppeteer-core": "^23.5.1",
+    "puppeteer-core": "^24.4.0",
     "rimraf": "^6.0.1",
     "sharp": "^0.33.5",
     "ts-node": "^10.9.2",

--- a/e2e-cypress/files/package.json
+++ b/e2e-cypress/files/package.json
@@ -30,7 +30,7 @@
     "mochawesome": "^7.1.3",
     "npm-run-all": "^4.1.5",
     "otplib": "^12.0.1",
-    "puppeteer": "^23.5.1",
+    "puppeteer-core": "^23.5.1",
     "rimraf": "^6.0.1",
     "sharp": "^0.33.5",
     "ts-node": "^10.9.2",

--- a/e2e-cypress/files/pdf-generator.ts
+++ b/e2e-cypress/files/pdf-generator.ts
@@ -26,7 +26,7 @@ const isLocal = process.env.NODE_ENV === 'local';
         continue;
       }
 
-      const executablePath = isLocal ? undefined : '/usr/bin/google-chrome';
+      const executablePath = isLocal ? undefined : '/usr/bin/microsoft-edge';
 
       const browser = await puppeteer.launch({ args: ['--no-sandbox'],
         executablePath

--- a/e2e-cypress/files/pdf-generator.ts
+++ b/e2e-cypress/files/pdf-generator.ts
@@ -1,4 +1,4 @@
-import * as puppeteer from 'puppeteer';
+import * as puppeteer from 'puppeteer-core';
 import * as path from 'path';
 import * as fs from 'fs';
 import baseConfig from './cypress.config';


### PR DESCRIPTION
The e2e-cypress quickstarter currently includes Puppeteer as dependency. The Puppeteer library always downloads its own copy of chrome. This has the advantage that we can be sure that the Chrome version is compatible with Puppeteer. BUT we do not use that downloaded copy (as we specify the `executablePath` of the global installation of chrome: `/usr/bin/google-chrome`). Therefore, I see no reason why we should need that additional copy of chrome (which is installed by Puppeteer). 
By switching from `puppeteer` to `puppeteer-core` we skip the installation of chrome during the postinstall step. In fact, `puppeteer` is using `puppeteer-core` in the background. The only differences between those to packages is the former one installs chrome and it can be configured with some `PUPPETEER_*` env vars which are ignored by the latter one (and not used by us; References: https://devdocs.io/puppeteer/ and https://how.dev/answers/puppeteer-vs-puppeteer-core).

This change reduced the time needed for the install dependencies stage from ~ 1 min to ~ 18 seconds in my case (not a representative study 😉)

I also switched from chrome to edge for the pdf generation. Therefore, the whole e2e-cypress quickstarter only depends on one browser (I would be open to revert that change).

Closes #...
Fixes #...

Tasks: 
- [ ] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
