### PR TITLE
e2e-cypress small improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Set Request and Limits with Ephemeral storage and Make use of Nexus in terraform agents ([#1104](https://github.com/opendevstack/ods-quickstarters/pull/1104))
 - Fix ds-streamlit uses old CI colors ([#978](https://github.com/opendevstack/ods-quickstarters/issues/978))
 - Remove unnecessary evidence printing in e2e-spock-geb ([#1106](https://github.com/opendevstack/ods-quickstarters/pull/1106))
+- Use npm ci in e2e-cypress quickstarter ([#1114](https://github.com/opendevstack/ods-quickstarters/pull/1114))
+- Better TypeScript support in e2e-cypress quickstarter ([#1114](https://github.com/opendevstack/ods-quickstarters/pull/1114))
 
 ### Fixed
 

--- a/e2e-cypress/Jenkinsfile
+++ b/e2e-cypress/Jenkinsfile
@@ -23,4 +23,10 @@ odsQuickstarterPipeline(
   odsQuickstarterStageRenderJenkinsfile(context)
 
   odsQuickstarterStageRenderSonarProperties(context)
+
+  stage('Create package-lock.json') {
+    dir(context.targetDir) {
+      sh 'npm install --package-lock-only'
+    }
+  }
 }

--- a/e2e-cypress/Jenkinsfile.template
+++ b/e2e-cypress/Jenkinsfile.template
@@ -32,6 +32,7 @@ odsComponentPipeline(
 
   def targetDirectory = "${context.projectId}/${context.componentId}/${context.gitBranch.replaceAll('/', '-')}/${context.buildNumber}"
 
+  stageInstall(context)
   stageTest(context)
   odsComponentStageScanWithSonar(context)
 
@@ -67,6 +68,13 @@ odsComponentPipeline(
   }
 }
 
+
+def stageInstall(def context) {
+  stage('Install dependencies') {
+    sh 'npm ci'
+  }
+}
+
 def stageTest(def context) {
   stage('Functional Tests') {
     // Define your DEV and QA base URLs in a config map in OpenShift; please adapt variable names to your OpenShift config
@@ -97,8 +105,6 @@ def stageTest(def context) {
         // usernamePassword(credentialsId: "${context.projectId}-cd-e2e-user", passwordVariable: 'CYPRESS_PASSWORD', usernameVariable: 'CYPRESS_USERNAME'),
         // string(credentialsId: "${context.projectId}-cd-otp-secret", variable: 'OTP_SECRET')
       ]) {
-        sh 'npm install'
-
         // Note: Testing in the production environment is not enabled by default as it can lead to unintended consequences,
         // including potential downtime, data corruption, or exposure of sensitive information.
         // This block is designed to skip acceptance and integration tests in the production environment to avoid these risks.

--- a/e2e-cypress/Jenkinsfile.template
+++ b/e2e-cypress/Jenkinsfile.template
@@ -33,6 +33,7 @@ odsComponentPipeline(
   def targetDirectory = "${context.projectId}/${context.componentId}/${context.gitBranch.replaceAll('/', '-')}/${context.buildNumber}"
 
   stageInstall(context)
+  stageTypeCheck(context)
   stageTest(context)
   odsComponentStageScanWithSonar(context)
 
@@ -72,6 +73,12 @@ odsComponentPipeline(
 def stageInstall(def context) {
   stage('Install dependencies') {
     sh 'npm ci'
+  }
+}
+
+def stageTypeCheck(def context) {
+  stage('Check types') {
+    sh 'npx tsc --noEmit'
   }
 }
 

--- a/e2e-cypress/files/cypress-acceptance.config.ts
+++ b/e2e-cypress/files/cypress-acceptance.config.ts
@@ -6,11 +6,11 @@ export default defineConfig({
   reporterOptions: {
     ...baseConfig.reporterOptions,
     mochawesomeReporterOptions: {
-      ...baseConfig.reporterOptions.mochawesomeReporterOptions,
+      ...baseConfig.reporterOptions?.mochawesomeReporterOptions,
       reportFilename: 'acceptance-mochawesome',
     },
     reportersCustomReporterJsReporterOptions: {
-      ...baseConfig.reporterOptions.reportersCustomReporterJsReporterOptions,
+      ...baseConfig.reporterOptions?.reportersCustomReporterJsReporterOptions,
       mochaFile: 'build/test-results/acceptance-junit-[hash].xml',
     },
   },

--- a/e2e-cypress/files/cypress-installation.config.ts
+++ b/e2e-cypress/files/cypress-installation.config.ts
@@ -6,11 +6,11 @@ export default defineConfig({
   reporterOptions: {
     ...baseConfig.reporterOptions,
     mochawesomeReporterOptions: {
-      ...baseConfig.reporterOptions.mochawesomeReporterOptions,
+      ...baseConfig.reporterOptions?.mochawesomeReporterOptions,
       reportFilename: 'installation-mochawesome',
     },
     reportersCustomReporterJsReporterOptions: {
-      ...baseConfig.reporterOptions.reportersCustomReporterJsReporterOptions,
+      ...baseConfig.reporterOptions?.reportersCustomReporterJsReporterOptions,
       mochaFile: 'build/test-results/installation-junit-[hash].xml',
     },
   },

--- a/e2e-cypress/files/cypress-integration.config.ts
+++ b/e2e-cypress/files/cypress-integration.config.ts
@@ -6,11 +6,11 @@ export default defineConfig({
   reporterOptions: {
     ...baseConfig.reporterOptions,
     mochawesomeReporterOptions: {
-      ...baseConfig.reporterOptions.mochawesomeReporterOptions,
+      ...baseConfig.reporterOptions?.mochawesomeReporterOptions,
       reportFilename: 'integration-mochawesome',
     },
     reportersCustomReporterJsReporterOptions: {
-      ...baseConfig.reporterOptions.reportersCustomReporterJsReporterOptions,
+      ...baseConfig.reporterOptions?.reportersCustomReporterJsReporterOptions,
       mochaFile: 'build/test-results/integration-junit-[hash].xml',
     },
   },

--- a/e2e-cypress/files/pdf-generator.ts
+++ b/e2e-cypress/files/pdf-generator.ts
@@ -12,7 +12,7 @@ async function expandReportTestCases(htmlPage: puppeteer.Page) {
   });
 }
 
-const mochawesomeDir = path.resolve(__dirname, baseConfig.reporterOptions.mochawesomeReporterOptions.reportDir);
+const mochawesomeDir = path.resolve(__dirname, baseConfig.reporterOptions?.mochawesomeReporterOptions.reportDir ?? 'build/test-results/mochawesome');
 
 const isLocal = process.env.NODE_ENV === 'local';
 

--- a/e2e-cypress/files/support/commands.ts
+++ b/e2e-cypress/files/support/commands.ts
@@ -19,11 +19,11 @@ addLoginToAADWithMFA();
 declare global {
   namespace Cypress {
     interface Chainable<> {
-      loginToAAD(username: string, password: string);
-      loginToAADWithMFA(username: string, password: string);
-      sessionLoginWithMFA(username: string, password: string);
-      getTOTP();
-      addContextPath(title: string, screenshot: string);
+      loginToAAD(username: string, password: string): void;
+      loginToAADWithMFA(username: string, password: string): void;
+      sessionLoginWithMFA(username: string, password: string): void;
+      getTOTP(): Cypress.Chainable<string>;
+      addContextPath(title: string, screenshot: string): void;
     }
   }
 }

--- a/e2e-cypress/files/support/e2e.ts
+++ b/e2e-cypress/files/support/e2e.ts
@@ -8,7 +8,7 @@ beforeEach(function() {
 })
 
 afterEach(function() {
-  const testName = this.currentTest?.fullTitle().replace(/ /g, '_');
+  const testName = this.currentTest?.fullTitle().replace(/ /g, '_') || 'unknown';
   const fileName = `system-output-${String(testName)}.txt`;
   const filePath = `cypress/results/${fileName}`;
 

--- a/e2e-cypress/files/support/e2e.ts
+++ b/e2e-cypress/files/support/e2e.ts
@@ -8,8 +8,8 @@ beforeEach(function() {
 })
 
 afterEach(function() {
-  const testName = this.currentTest.fullTitle().replace(/ /g, '_');
-  const fileName = `system-output-${testName}.txt`;
+  const testName = this.currentTest?.fullTitle().replace(/ /g, '_');
+  const fileName = `system-output-${String(testName)}.txt`;
   const filePath = `cypress/results/${fileName}`;
 
   cy.writeFile(filePath, consoleLogs.join('\n'));

--- a/e2e-cypress/files/support/e2e.ts
+++ b/e2e-cypress/files/support/e2e.ts
@@ -9,7 +9,7 @@ beforeEach(function() {
 
 afterEach(function() {
   const testName = this.currentTest?.fullTitle().replace(/ /g, '_') || 'unknown';
-  const fileName = `system-output-${String(testName)}.txt`;
+  const fileName = `system-output-${testName}.txt`;
   const filePath = `cypress/results/${fileName}`;
 
   cy.writeFile(filePath, consoleLogs.join('\n'));

--- a/e2e-cypress/files/support/login-functions.ts
+++ b/e2e-cypress/files/support/login-functions.ts
@@ -78,8 +78,18 @@ export function addLoginToAAD() {
 export function addSessionLoginWithMFA() {
   Cypress.Commands.add('sessionLoginWithMFA', (username: string, password: string) => {
     cy.session('login', () => cy.loginToAADWithMFA(username, password), {
-      validate: () => cy.getAllLocalStorage().should(validateLocalStorage),
-      cacheAcrossSpecs: true
+      validate: () => new Promise((resolve, reject) => {
+        try {
+          cy.getAllLocalStorage()
+            .should(validateLocalStorage)
+            .then(() => {
+              resolve()
+            })
+        } catch (e) {
+          reject(e)
+        }
+      }),
+      cacheAcrossSpecs: true,
     })
   })
 }

--- a/e2e-cypress/files/support/login-functions.ts
+++ b/e2e-cypress/files/support/login-functions.ts
@@ -98,8 +98,7 @@ export function addLoginToAADWithMFA() {
   Cypress.Commands.add('loginToAADWithMFA', (username: string, password: string) => {
     loginViaAAD(username, password);
     cy.getTOTP().then((otp) => {
-      const objOTP = { otp }
-      cy.origin('https://login.microsoftonline.com/', { args: objOTP }, ({ otp }) => {
+      cy.origin('https://login.microsoftonline.com/', { args: { otp } }, ({ otp }) => {
         cy.get("[name='otc']").type(otp)
         cy.get('input[type="submit"]').click()
       })

--- a/e2e-cypress/files/support/login-functions.ts
+++ b/e2e-cypress/files/support/login-functions.ts
@@ -97,8 +97,8 @@ export function addSessionLoginWithMFA() {
 export function addLoginToAADWithMFA() {
   Cypress.Commands.add('loginToAADWithMFA', (username: string, password: string) => {
     loginViaAAD(username, password);
-    cy.getTOTP().then((otp1) => {
-      const objOTP = { otp: otp1 }
+    cy.getTOTP().then((otp) => {
+      const objOTP = { otp }
       cy.origin('https://login.microsoftonline.com/', { args: objOTP }, ({ otp }) => {
         cy.get("[name='otc']").type(otp)
         cy.get('input[type="submit"]').click()
@@ -109,7 +109,7 @@ export function addLoginToAADWithMFA() {
 
 export function addGetTOTP() {
   Cypress.Commands.add('getTOTP', () => {
-    return authenticator.generate(Cypress.env('otp_secret'))
+    return cy.wrap(authenticator.generate(Cypress.env('otp_secret')));
   })
 }
 

--- a/e2e-cypress/files/support/test-evidence.ts
+++ b/e2e-cypress/files/support/test-evidence.ts
@@ -17,7 +17,7 @@ const logEvidence = (name: string, step: number, description: string, evidenceLo
   });
 }
 
-export const printTestDOMEvidence = (testName = 'unknown', testStep: number, selector: string, description: string) => {
+export const printTestDOMEvidence = (testName: string, testStep: number, selector: string, description: string) => {
   if (!selector) {
     throw new Error('selector must not NOT be undefined');
   }
@@ -26,7 +26,7 @@ export const printTestDOMEvidence = (testName = 'unknown', testStep: number, sel
   });
 };
 
-export const printTestPlainEvidence = (testName = 'unknown', testStep: number, expectedValue: string, actualValue: string, description: string) => {
+export const printTestPlainEvidence = (testName: string, testStep: number, expectedValue: string, actualValue: string, description: string) => {
   if (!expectedValue || !actualValue) {
     throw new Error('expectedValue and actualValue must not NOT be undefined');
   }
@@ -36,7 +36,7 @@ export const printTestPlainEvidence = (testName = 'unknown', testStep: number, e
   ]);
 };
 
-export const takeScreenshotEvidence = (testName = 'unknown', testStep: number, testSubStep: number = 1, description: string, skipMeta = false) => {
+export const takeScreenshotEvidence = (testName: string, testStep: number, testSubStep: number = 1, description: string, skipMeta = false) => {
   cy.wrap(null).then(() => {
     const data: Omit<ScreenshotEvidenceData, 'path' | 'takenAt'> &
       Partial<Pick<ScreenshotEvidenceData, 'path' | 'takenAt'>> = {

--- a/e2e-cypress/files/support/test-evidence.ts
+++ b/e2e-cypress/files/support/test-evidence.ts
@@ -17,7 +17,7 @@ const logEvidence = (name: string, step: number, description: string, evidenceLo
   });
 }
 
-export const printTestDOMEvidence = (testName: string, testStep: number, selector: string, description: string) => {
+export const printTestDOMEvidence = (testName = 'unknown', testStep: number, selector: string, description: string) => {
   if (!selector) {
     throw new Error('selector must not NOT be undefined');
   }
@@ -26,7 +26,7 @@ export const printTestDOMEvidence = (testName: string, testStep: number, selecto
   });
 };
 
-export const printTestPlainEvidence = (testName: string, testStep: number, expectedValue: string, actualValue: string, description: string) => {
+export const printTestPlainEvidence = (testName = 'unknown', testStep: number, expectedValue: string, actualValue: string, description: string) => {
   if (!expectedValue || !actualValue) {
     throw new Error('expectedValue and actualValue must not NOT be undefined');
   }
@@ -36,7 +36,7 @@ export const printTestPlainEvidence = (testName: string, testStep: number, expec
   ]);
 };
 
-export const takeScreenshotEvidence = (testName: string, testStep: number, testSubStep: number = 1, description: string, skipMeta = false) => {
+export const takeScreenshotEvidence = (testName = 'unknown', testStep: number, testSubStep: number = 1, description: string, skipMeta = false) => {
   cy.wrap(null).then(() => {
     const data: Omit<ScreenshotEvidenceData, 'path' | 'takenAt'> &
       Partial<Pick<ScreenshotEvidenceData, 'path' | 'takenAt'>> = {

--- a/e2e-cypress/files/tests/acceptance/acceptance.spec.cy.ts
+++ b/e2e-cypress/files/tests/acceptance/acceptance.spec.cy.ts
@@ -18,14 +18,16 @@ import { printTestDOMEvidence, printTestPlainEvidence, takeScreenshotEvidence } 
 describe('W3 application test', () => {
 
   it('Application is reachable', function () {
+    const testTitle = this.test?.fullTitle() || 'unknown';
+
     cy.visit('/html/tryit.asp?filename=tryhtml_basic_paragraphs');
     cy.title().should('include', 'Tryit Editor');
-    printTestDOMEvidence(this.test?.fullTitle(), 1, '#textareaCode', 'code area');
-    printTestDOMEvidence(this.test?.fullTitle(), 2, '#iframecontainer', 'rendered code area');
-    takeScreenshotEvidence(this.test?.fullTitle(), 3, 1, 'screenshot');
-    takeScreenshotEvidence(this.test?.fullTitle(), 3, 2, 'screenshot substep 2');
+    printTestDOMEvidence(testTitle, 1, '#textareaCode', 'code area');
+    printTestDOMEvidence(testTitle, 2, '#iframecontainer', 'rendered code area');
+    takeScreenshotEvidence(testTitle, 3, 1, 'screenshot');
+    takeScreenshotEvidence(testTitle, 3, 2, 'screenshot substep 2');
     cy.title().then(title => {
-      printTestPlainEvidence(this.test?.fullTitle(), 4, title, 'Tryit Editor', 'Title should include Tryit Editor');
+      printTestPlainEvidence(testTitle, 4, title, 'Tryit Editor', 'Title should include Tryit Editor');
     });
   });
 });

--- a/e2e-cypress/files/tests/acceptance/acceptance.spec.cy.ts
+++ b/e2e-cypress/files/tests/acceptance/acceptance.spec.cy.ts
@@ -20,12 +20,12 @@ describe('W3 application test', () => {
   it('Application is reachable', function () {
     cy.visit('/html/tryit.asp?filename=tryhtml_basic_paragraphs');
     cy.title().should('include', 'Tryit Editor');
-    printTestDOMEvidence(this.test?.fullTitle() ?? '', 1, '#textareaCode', 'code area');
-    printTestDOMEvidence(this.test?.fullTitle() ?? '', 2, '#iframecontainer', 'rendered code area');
-    takeScreenshotEvidence(this.test?.fullTitle() ?? '', 3, 1, 'screenshot');
-    takeScreenshotEvidence(this.test?.fullTitle() ?? '', 3, 2, 'screenshot substep 2');
+    printTestDOMEvidence(this.test?.fullTitle(), 1, '#textareaCode', 'code area');
+    printTestDOMEvidence(this.test?.fullTitle(), 2, '#iframecontainer', 'rendered code area');
+    takeScreenshotEvidence(this.test?.fullTitle(), 3, 1, 'screenshot');
+    takeScreenshotEvidence(this.test?.fullTitle(), 3, 2, 'screenshot substep 2');
     cy.title().then(title => {
-      printTestPlainEvidence(this.test?.fullTitle() ?? '', 4, title, 'Tryit Editor', 'Title should include Tryit Editor');
+      printTestPlainEvidence(this.test?.fullTitle(), 4, title, 'Tryit Editor', 'Title should include Tryit Editor');
     });
   });
 });

--- a/e2e-cypress/files/tests/acceptance/acceptance.spec.cy.ts
+++ b/e2e-cypress/files/tests/acceptance/acceptance.spec.cy.ts
@@ -20,12 +20,12 @@ describe('W3 application test', () => {
   it('Application is reachable', function () {
     cy.visit('/html/tryit.asp?filename=tryhtml_basic_paragraphs');
     cy.title().should('include', 'Tryit Editor');
-    printTestDOMEvidence(this.test.fullTitle(), 1, '#textareaCode', 'code area');
-    printTestDOMEvidence(this.test.fullTitle(), 2, '#iframecontainer', 'rendered code area');
-    takeScreenshotEvidence(this.test.fullTitle(), 3, 1, 'screenshot');
-    takeScreenshotEvidence(this.test.fullTitle(), 3, 2, 'screenshot substep 2');
+    printTestDOMEvidence(this.test?.fullTitle() ?? '', 1, '#textareaCode', 'code area');
+    printTestDOMEvidence(this.test?.fullTitle() ?? '', 2, '#iframecontainer', 'rendered code area');
+    takeScreenshotEvidence(this.test?.fullTitle() ?? '', 3, 1, 'screenshot');
+    takeScreenshotEvidence(this.test?.fullTitle() ?? '', 3, 2, 'screenshot substep 2');
     cy.title().then(title => {
-      printTestPlainEvidence(this.test.fullTitle(), 4, title, 'Tryit Editor', 'Title should include Tryit Editor');
+      printTestPlainEvidence(this.test?.fullTitle() ?? '', 4, title, 'Tryit Editor', 'Title should include Tryit Editor');
     });
   });
 });

--- a/e2e-cypress/files/tsconfig.json
+++ b/e2e-cypress/files/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "target": "es5",
     "lib": ["es2017", "dom"],
-    "types": ["cypress", "node"]
+    "types": ["cypress", "node"],
+    "skipLibCheck": true
   },
   "include": ["**/*.ts"]
 }

--- a/e2e-cypress/files/tsconfig.json
+++ b/e2e-cypress/files/tsconfig.json
@@ -3,7 +3,8 @@
     "target": "es5",
     "lib": ["es2017", "dom"],
     "types": ["cypress", "node"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": true
   },
   "include": ["**/*.ts"]
 }

--- a/e2e-cypress/testdata/golden/jenkins-build-stages.json
+++ b/e2e-cypress/testdata/golden/jenkins-build-stages.json
@@ -4,6 +4,10 @@
     "status": "SUCCESS"
   },
   {
+    "stage": "Install dependencies",
+    "status": "SUCCESS"
+  },
+  {
     "stage": "Integration Test",
     "status": "SUCCESS"
   },

--- a/e2e-cypress/testdata/golden/jenkins-build-stages.json
+++ b/e2e-cypress/testdata/golden/jenkins-build-stages.json
@@ -8,6 +8,10 @@
     "status": "SUCCESS"
   },
   {
+    "stage": "Check types",
+    "status": "SUCCESS"
+  },
+  {
     "stage": "Integration Test",
     "status": "SUCCESS"
   },

--- a/e2e-cypress/testdata/golden/jenkins-provision-stages.json
+++ b/e2e-cypress/testdata/golden/jenkins-provision-stages.json
@@ -20,6 +20,10 @@
     "status": "SUCCESS"
   },
   {
+    "stage": "Create package-lock.json",
+    "status": "SUCCESS"
+  },
+  {
     "stage": "Push to remote",
     "status": "SUCCESS"
   }


### PR DESCRIPTION
This PR includes the following improvements for e2e-cypress (as suggestion; I am happy about feedback)
- it switches from `npm install` to `npm clean-install` (`npm ci`)
  `npm install` is usually not a good idea in a continuous integration pipeline as it may update packages. `npm clean-install` will ensure it does not update any packages and will only use what is defined in the package-lock.json (means the exact version used by the developer).
- the current released version has some TypeScript errors (without any change to the TypeScript settings). Those are fixed by enabling `skipLibCheck` and fixing one type ([here](https://github.com/opendevstack/ods-quickstarters/commit/60a5fe78c60b01b2eaf89a455320a34847130acb#diff-47328c3ccece2c1955b36db3edd3a2141c7f84426d2dccdd42b32dc4ab29ee48R81))
- enables the strict rule set (as recommended)
  It also fixes all findings introduced by that
- Adds type checking to Jenkins to support reviews (by ensuring the type check succeeds)

Closes #...
Fixes #...

Tasks: 
- [ ] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
