### PR TITLE
Adapt Jenkinsfile to Jira Zephyr ODS integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - Use npm ci in e2e-cypress quickstarter & Better TypeScript support in e2e-cypress quickstarter ([#1114](https://github.com/opendevstack/ods-quickstarters/pull/1114))
 - e2e-cypress get rid of additional chrome installation and switch to edge for pdf generation ([#1112](https://github.com/opendevstack/ods-quickstarters/pull/1112))
+- Fix for the integration of the Python Quickstarter and Zephyr ODS integration ([#1125](https://github.com/opendevstack/ods-quickstarters/pull/1125))
 
 ### Fixed
 

--- a/be-python-flask/Jenkinsfile.template
+++ b/be-python-flask/Jenkinsfile.template
@@ -51,6 +51,7 @@ def stageTestSuite(def context) {
       script: """
         . ./testsuite/bin/activate
         PYTHONPATH=src python3.12 -m pytest --junitxml=tests.xml -o junit_family=xunit2 --cov-report term-missing --cov-report xml --cov=src -o testpaths=tests
+        sed -i-e 's/test_//g' tests.xml
       """,
       returnStatus: true
     )


### PR DESCRIPTION
Fix for the integration of the Python Quickstarter and Zephyr ODS integration.

Pytest only executes Unit tests that start with the prefix ``test_`` but the integration with Zephyr in OpenDevStack does not work properly with XML reports with that prefix