### PR TITLE
fix test credentials for e2e-etl-python

### DIFF
--- a/e2e-etl-python/test.yml.template
+++ b/e2e-etl-python/test.yml.template
@@ -1,8 +1,8 @@
 region: eu-west-1
 
 credentials:
-  key: @project_id@-cd-aws-access-key-id-test
-  secret: @project_id@-cd-aws-secret-access-key-test
+  key: @project_id@-cd-aws-access-key-id-qa
+  secret: @project_id@-cd-aws-secret-access-key-qa
 
 account: "<your_aws_account_id>"
 


### PR DESCRIPTION
Adapted the aws test credentials of e2e-etl-python in test environment to the correct values (as it is in inf-terraform-aws; See: https://github.com/opendevstack/ods-quickstarters/blob/b6460f7e4a1045848034d9fc9bf4e225d75d214c/inf-terraform-aws/test.yml.template)

Closes #...
Fixes #...

Tasks: 
- [ ] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
