### PR TITLE
Rust Quickstarter maintenance and cargo deny fix

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -124,12 +124,12 @@ jobs:
         working-directory: common/jenkins-agents/rust/docker
         run: |
           docker build --tag agent-rust-test-ubi8 --file Dockerfile.ubi8 \
-            --build-arg rustVersion=1.88.0 \
+            --build-arg rustVersion=1.94.1 \
             --build-arg rustToolchain=x86_64-unknown-linux-gnu \
-            --build-arg cargoNextestVersion=0.9.94 \
-            --build-arg cargoLlvmCovVersion=0.6.16 \
-            --build-arg cargoGenerateVersion=0.23.3 \
-            --build-arg cargoDenyVersion=0.18.2 \
+            --build-arg cargoNextestVersion=0.9.132 \
+            --build-arg cargoLlvmCovVersion=0.8.5 \
+            --build-arg cargoGenerateVersion=0.23.8 \
+            --build-arg cargoDenyVersion=0.19.1 \
             .
 
   jenkins-agent-terraform-2306-ubi8:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
 - Test remove sonar profile check ([#1155](https://github.com/opendevstack/ods-quickstarters/pull/1155))
 
 ### Changed
+- Updated Rust Quickstarter and Agent to version 1.94.1 ([#1140](https://github.com/opendevstack/ods-quickstarters/issues/1140))
 
 ### Fixed
+- Fixed Cargo Deny failure with updating to version 0.19.1 ([#1140](https://github.com/opendevstack/ods-quickstarters/issues/1140))
 
 ## [4.12.1] - 2026-03-16
 ### Fixed

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,10 +3,10 @@
 /be-golang-plain/ @henrjk
 /be-java-springboot/ @stitakis @renedupont
 /be-python-flask/ @buegelbeatz @henrjk @gerardcl
-/be-rust-axum/ @gerardcl @flightlama
+/be-rust-axum/ @gerardcl @flightlama @pschugt
 /be-scala-play/ @oalyman
 /be-typescript-express/ @sino92
-/docker-plain/ 
+/docker-plain/
 /ds-jupyter-lab/ @gerardcl @hugowschneider
 /ds-rshiny/ @gerardcl
 /ds-streamlit/ @sklingel

--- a/be-rust-axum/rust-template/.pre-commit-config.yaml
+++ b/be-rust-axum/rust-template/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: gitleaks
   - repo: https://github.com/EmbarkStudios/cargo-deny
-    rev: 0.18.2
+    rev: 0.18.9
     hooks:
       - id: cargo-deny
         args: ["--all-features", "check"] # optionally modify the arguments for cargo-deny (default arguments shown here)

--- a/be-rust-axum/rust-template/Cargo.toml
+++ b/be-rust-axum/rust-template/Cargo.toml
@@ -3,7 +3,7 @@
 name = "{{project-name}}"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94.1"
 description = "{{project-name}} component - from the OpenDevStack Rust QuickStarter."
 license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,21 +11,27 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # one can add more dependencies via cargo to Cargo.toml as shown next: cargo add axum -F axum/http2
 axum = { version = "0.8", features = ["http2", "macros", "multipart"] }
-tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "signal"] }
+tokio = { version = "1.51", features = ["rt-multi-thread", "macros", "signal"] }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-http = "1.3"
+http = "1.4"
 http-body-util = "0.1"
 # Highly encouraged to use URL encoding when working with any URI string
 # urlencoding = "2.1"
-bytes = "1.7"
+bytes = "1.11"
 
 thiserror = "2.0"
 
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["tracing", "env-filter", "json", "ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", features = [
+  "tracing",
+  "env-filter",
+  "json",
+  "ansi",
+  "fmt",
+] }
 
 lazy_static = "1.5"
 
@@ -73,5 +79,7 @@ dotenvy = "0.15"
 
 [dev-dependencies]
 # mockito = "1.7"  # mockito is recommended when requiring mocking network requests to either external or internal services
-temp-env = { version = "0.3", features = ["async_closure"] }  # it is highly recommended the usage of cargo nextest run instead of cargo test; this way each test runs on its own process
+temp-env = { version = "0.3", features = [
+  "async_closure",
+] } # it is highly recommended the usage of cargo nextest run instead of cargo test; this way each test runs on its own process
 tower = { version = "0.5", features = ["util"] }

--- a/be-rust-axum/rust-template/metadata.yml
+++ b/be-rust-axum/rust-template/metadata.yml
@@ -1,6 +1,6 @@
 ---
 name: Axum - Rust web framework
-description: "Axum is an ergonomic and modular web framework built with Tokio, Tower, and Hyper; written in Rust. Technologies: Axum 0.8.x, Rust 1.88.x"
+description: "Axum is an ergonomic and modular web framework built with Tokio, Tower, and Hyper; written in Rust. Technologies: Axum 0.8.x, Rust 1.94.x"
 supplier: https://github.com/tokio-rs/axum
 version: 4.x
 type: ods

--- a/be-rust-axum/rust-template/rust-toolchain.toml
+++ b/be-rust-axum/rust-template/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.94.1"

--- a/common/jenkins-agents/rust/docker/Dockerfile.ubi8
+++ b/common/jenkins-agents/rust/docker/Dockerfile.ubi8
@@ -1,6 +1,6 @@
 FROM opendevstackorg/ods-jenkins-agent-base-ubi8:latest
 
-LABEL maintainer="Gerard C.L. <gerard.castillo@boehringer-ingelheim.com>"
+LABEL maintainer="Gerard C.L. <gerard.castillo@boehringer-ingelheim.com>, Philipp Schugt <philipp.schugt@boehringer-ingelheim.com>"
 
 ARG rustVersion
 ARG rustToolchain

--- a/common/jenkins-agents/rust/docker/Dockerfile.ubi9
+++ b/common/jenkins-agents/rust/docker/Dockerfile.ubi9
@@ -1,6 +1,6 @@
 FROM opendevstackorg/ods-jenkins-agent-base-ubi8:latest
 
-LABEL maintainer="Gerard C.L. <gerard.castillo@boehringer-ingelheim.com>"
+LABEL maintainer="Gerard C.L. <gerard.castillo@boehringer-ingelheim.com>, Philipp Schugt <philipp.schugt@boehringer-ingelheim.com>"
 
 ARG rustVersion
 ARG rustToolchain

--- a/common/jenkins-agents/rust/ocp-config/bc.yml
+++ b/common/jenkins-agents/rust/ocp-config/bc.yml
@@ -19,7 +19,7 @@ parameters:
 - name: RUST_VERSION
   description: "The Rust version"
   required: true
-  value: "1.88.0"
+  value: "1.94.1"
 - name: RUST_TOOLCHAIN
   description: "The Rust target toolchain"
   required: true
@@ -27,19 +27,19 @@ parameters:
 - name: CARGO_NEXTEST_VERSION
   description: "The Cargo Nextest testing framework version"
   required: true
-  value: "0.9.94"
+  value: "0.9.132"
 - name: CARGO_LLVM_COV_VERSION
   description: "The Cargo LLVM Coverage tool version"
   required: true
-  value: "0.6.16"
+  value: "0.8.5"
 - name: CARGO_GENERATE_VERSION
   description: "The Cargo Generate tool version"
   required: true
-  value: "0.23.3"
+  value: "0.23.8"
 - name: CARGO_DENY_VERSION
   description: "The Cargo Deny tool version"
   required: true
-  value: "0.18.2"
+  value: "0.19.1"
 objects:
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig

--- a/docs/modules/jenkins-agents/pages/rust.adoc
+++ b/docs/modules/jenkins-agents/pages/rust.adoc
@@ -11,7 +11,7 @@ Rust installation is managed by `rustup`, which offers a convenient way to load 
 
 And, the version defined in the `rust-toolchain` file is the one that the Jenkins Agent will use (even if it is not the default). That file MUST be in the root of the projects' repository.
 
-Default Minimum Supported Rust Version (MSRV) **1.88**.
+Default Minimum Supported Rust Version (MSRV) **1.94.1**.
 
 Default Rust edition in use is **2024**. See https://doc.rust-lang.org/edition-guide/introduction.html[Rust Edition Guide] for further information.
 

--- a/docs/modules/quickstarters/pages/be-rust-axum.adoc
+++ b/docs/modules/quickstarters/pages/be-rust-axum.adoc
@@ -71,11 +71,11 @@ It contains the basic setup for Docker, Jenkins, SonarQube and OpenShift.
 
 == Frameworks used
 
-* https://www.rust-lang.org/[Rust 1.88.x]
+* https://www.rust-lang.org/[Rust 1.94.x]
 * https://github.com/tokio-rs/axum[Axum 0.8.x]
 * https://nexte.st/[Nextest 0.9.x]
-* https://github.com/taiki-e/cargo-llvm-cov/[LLVM coverage 0.6.x]
-* https://github.com/EmbarkStudios/cargo-deny/[Deny 0.18.x]
+* https://github.com/taiki-e/cargo-llvm-cov/[LLVM coverage 0.8.x]
+* https://github.com/EmbarkStudios/cargo-deny/[Deny 0.19.x]
 
 == Usage - how do you start after you provisioned this quickstarter
 
@@ -243,7 +243,7 @@ which makes use of the crate `rustls` and disabling default features, like:
 
 ```
 [dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.13", features = ["stream", "json"]}
 ```
 
 See reqwest's https://docs.rs/reqwest/latest/reqwest/#optional-features[features list] for further learning.


### PR DESCRIPTION
- Rust to stable version 1.94.1 
- Cargo Deny to 0.19.1 
- Cargo Nextest to 0.9.132
- Cargo LLVM to 0.8.5 
- Cargo Generate to 0.23.8


Relates #1141 
Fixes #1140 

Tasks: 
- [X] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
