### PR TITLE
Increase default memory resources for Docker-plain Quickstarter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 
 ### Fixed
+- Increase Docker-plain QS default memory resources ([#1147](https://github.com/opendevstack/ods-quickstarters/pull/1147))
 
 ## [4.11.0] - 2025-12-03
 

--- a/docker-plain/files/chart/values.yaml
+++ b/docker-plain/files/chart/values.yaml
@@ -105,11 +105,11 @@ securityContext: {}
 resources:
   limits:
     cpu: 100m
-    memory: 32Mi
+    memory: 64Mi
     ephemeral-storage: 1Mi
   requests:
     cpu: 10m
-    memory: 16Mi
+    memory: 32Mi
     ephemeral-storage: 1Mi
 
 ## Before enabling check the official ODS documentation about replicate support: https://www.opendevstack.org/ods-documentation/opendevstack/latest/jenkins-shared-library/orchestration-pipeline.html#_known_limitations


### PR DESCRIPTION
Increase Docker Plain default memory resources as by default container restarts and reaches OOMKilled
