### PR TITLE
fix: allure-commandline version in e2e-etl-python quickstarter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 - Updated Rust Quickstarter and Agent to version 1.94.1 ([#1140](https://github.com/opendevstack/ods-quickstarters/issues/1140))
+- Freeze allure-commandline version in e2e-etl-python quickstarter ([#1158](https://github.com/opendevstack/ods-quickstarters/issues/1158))
 
 ### Fixed
 - Fixed Cargo Deny failure with updating to version 0.19.1 ([#1140](https://github.com/opendevstack/ods-quickstarters/issues/1140))

--- a/e2e-etl-python/files/modules/codebuild/main.tf
+++ b/e2e-etl-python/files/modules/codebuild/main.tf
@@ -35,7 +35,7 @@ resource "aws_codebuild_project" "build_project" {
         pre_build:
           commands:
             - pip install -r requirements.txt
-            - npm install -g allure-commandline --save-dev
+            - npm install -g allure-commandline@2.41.0 --save-dev
 
         build:
           commands:

--- a/e2e-etl-python/files/pyproject.toml
+++ b/e2e-etl-python/files/pyproject.toml
@@ -1,3 +1,3 @@
 [project]
 name = "e2e-etl-python"
-version = "1.0.0"
+version = "1.0.1"


### PR DESCRIPTION
Currently the allure-commandline npm package which is installed withing the codebuild/codepipeline is not fixed and will install the latest version. This causes that the environment is not predictable.

Tasks: 
- [ ] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
