### PR TITLE
feat: update cargo tools and version, replaced envy with config-rs

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -246,12 +246,12 @@ jobs:
         working-directory: common/jenkins-agents/rust/docker
         run: |
           docker build --tag agent-rust-test-ubi9 --file Dockerfile.ubi9 \
-            --build-arg rustVersion=1.94.1 \
+            --build-arg rustVersion=1.96.0 \
             --build-arg rustToolchain=x86_64-unknown-linux-gnu \
-            --build-arg cargoNextestVersion=0.9.132 \
-            --build-arg cargoLlvmCovVersion=0.8.5 \
-            --build-arg cargoGenerateVersion=0.23.8 \
-            --build-arg cargoDenyVersion=0.19.1 \
+            --build-arg cargoNextestVersion=0.9.138 \
+            --build-arg cargoLlvmCovVersion=0.8.7 \
+            --build-arg cargoGenerateVersion=0.23.12 \
+            --build-arg cargoDenyVersion=0.19.9 \
             .
 
   jenkins-agent-terraform-2306-ubi9:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 ### Added
+- Added config-rs to rust template ([#1162](https://github.com/opendevstack/ods-quickstarters/issues/1162))
 - Added rhel9 dockerfiles for all jenkins agents ([#1140](https://github.com/opendevstack/ods-quickstarters/pull/1140))
 - Test remove sonar profile check ([#1155](https://github.com/opendevstack/ods-quickstarters/pull/1155))
 - Update base java version to java 21, remove ubi8 and fix tests ([#1156](https://github.com/opendevstack/ods-quickstarters/pull/1156))
 
 ### Changed
+- Updated Rust Quickstarter and Agent to version 1.96.0 ([#1162](https://github.com/opendevstack/ods-quickstarters/issues/1162))
 - Updated Rust Quickstarter and Agent to version 1.94.1 ([#1140](https://github.com/opendevstack/ods-quickstarters/issues/1140))
 
 ### Fixed

--- a/be-rust-axum/rust-template/.pre-commit-config.yaml
+++ b/be-rust-axum/rust-template/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.25.1
+    rev: v8.30.1
     hooks:
       - id: gitleaks
   - repo: https://github.com/EmbarkStudios/cargo-deny
-    rev: 0.18.9
+    rev: 0.19.9
     hooks:
       - id: cargo-deny
         args: ["--all-features", "check"] # optionally modify the arguments for cargo-deny (default arguments shown here)

--- a/be-rust-axum/rust-template/Cargo.toml
+++ b/be-rust-axum/rust-template/Cargo.toml
@@ -3,7 +3,7 @@
 name = "{{project-name}}"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.94.1"
+rust-version = "1.96.0"
 description = "{{project-name}} component - from the OpenDevStack Rust QuickStarter."
 license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # one can add more dependencies via cargo to Cargo.toml as shown next: cargo add axum -F axum/http2
 axum = { version = "0.8", features = ["http2", "macros", "multipart"] }
-tokio = { version = "1.51", features = ["rt-multi-thread", "macros", "signal"] }
+tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "signal"] }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -20,7 +20,7 @@ http = "1.4"
 http-body-util = "0.1"
 # Highly encouraged to use URL encoding when working with any URI string
 # urlencoding = "2.1"
-bytes = "1.11"
+bytes = "1.12"
 
 thiserror = "2.0"
 
@@ -34,12 +34,11 @@ tracing-subscriber = { version = "0.3", features = [
 ] }
 
 lazy_static = "1.5"
-
-envy = "0.4"
 dotenvy = "0.15"
+config = "0.15"
 
 # HTTP middlewares from Tower crate, to be added to router.rs.
-# tower-http = { version = "0.6", features = [
+# tower-http = { version = "0.7", features = [
 #     "trace",
 #     "compression-br",
 #     "propagate-header",
@@ -48,7 +47,7 @@ dotenvy = "0.15"
 # ] }
 
 # SQLx is the recommended safe and performant package to work with relational DBs like PostgreSQL; check official docs
-# sqlx = { version = "0.8", features = [
+# sqlx = { version = "0.9", features = [
 #   "runtime-tokio",
 #   "tls-rustls-ring-native-roots",
 #   "postgres",
@@ -60,17 +59,17 @@ dotenvy = "0.15"
 # ]}
 
 # OTEL; check official docs
-# opentelemetry = { version = "0.29", features = ["trace", "metrics"] }
-# opentelemetry_sdk = { version = "0.29", features = ["rt-tokio"] }
-# opentelemetry-otlp = { version = "0.29", features = ["http-proto", "reqwest-client", "reqwest-rustls"] }
-# opentelemetry-http = { version = "0.29" }
-# opentelemetry-stdout = { version = "0.29", features = ["trace"] }
-# opentelemetry-appender-tracing = { version = "0.29" }
-# opentelemetry-semantic-conventions = { version = "0.29" }
-# tracing-opentelemetry = { version = "0.30" }
+# opentelemetry = { version = "0.32", features = ["trace", "metrics"] }
+# opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
+# opentelemetry-otlp = { version = "0.32", features = ["http-proto", "reqwest-blocking-client"] }
+# opentelemetry-http = { version = "0.32" }
+# opentelemetry-stdout = { version = "0.32", features = ["trace"] }
+# opentelemetry-appender-tracing = { version = "0.32" }
+# opentelemetry-semantic-conventions = { version = "0.32" }
+# tracing-opentelemetry = { version = "0.33" }
 
 # OpenAPI; check official docs
-# utoipa = { version = "5.3", features = ["axum_extras", "uuid", "chrono"] }
+# utoipa = { version = "5.5", features = ["axum_extras", "uuid", "chrono"] }
 # utoipa-axum = "0.2"
 # utoipa-swagger-ui = { version = "9.0", features = ["axum"] }
 # # utoipa-redoc = { version = "5.0", features = ["axum"] }

--- a/be-rust-axum/rust-template/README.md
+++ b/be-rust-axum/rust-template/README.md
@@ -21,6 +21,12 @@ The provided pre-commit hooks are:
 
 **NOTE**: the cargo hooks also run in Jenkins CICD, but cargo deny is disabled by default, see Jenkinsfile.
 
+## Configuration with config-rs
+
+This project uses [config-rs](https://github.com/rust-cli/config-rs) for configuration management. The configuration is loaded from environment variables and `.env` files. The `Settings` struct in `src/config/settings.rs` defines the configuration options for the application.
+
+It enables Layered configuration system for Rust applications (with strong support for [12-factor](https://12factor.net/config) applications).
+
 ## Adding caching in your CICD
 
 One can improve the build pipeline time by implementing a caching mechanism as shown next:

--- a/be-rust-axum/rust-template/metadata.yml
+++ b/be-rust-axum/rust-template/metadata.yml
@@ -1,6 +1,6 @@
 ---
 name: Axum - Rust web framework
-description: "Axum is an ergonomic and modular web framework built with Tokio, Tower, and Hyper; written in Rust. Technologies: Axum 0.8.x, Rust 1.94.x"
+description: "Axum is an ergonomic and modular web framework built with Tokio, Tower, and Hyper; written in Rust. Technologies: Axum 0.8.x, Rust 1.96.x"
 supplier: https://github.com/tokio-rs/axum
 version: 4.x
 type: ods

--- a/be-rust-axum/rust-template/rust-toolchain.toml
+++ b/be-rust-axum/rust-template/rust-toolchain.toml
@@ -1,2 +1,7 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.96.0"
+# https://rust-lang.github.io/rustup/concepts/profiles.html
+profile = "default"
+# Pins the rust-analyzer LSP server to this toolchain so editors (VS Code, Zed, etc.)
+# use the same Rust version for analysis and clippy — not the system default.
+components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/be-rust-axum/rust-template/src/config/settings.rs
+++ b/be-rust-axum/rust-template/src/config/settings.rs
@@ -1,3 +1,4 @@
+use config::{Config, Environment};
 use dotenvy::dotenv;
 use lazy_static::lazy_static;
 use serde::Deserialize;
@@ -27,10 +28,11 @@ fn default_logging() -> String {
 }
 
 impl Settings {
-  pub fn new() -> Result<Self, envy::Error> {
+  pub fn new() -> Result<Self, config::ConfigError> {
     dotenv().ok();
-
-    let settings = envy::from_env::<Settings>()?;
-    Ok(settings)
+    let config = Config::builder()
+      .add_source(Environment::default())
+      .build()?;
+    config.try_deserialize()
   }
 }

--- a/common/jenkins-agents/rust/ocp-config/bc.yml
+++ b/common/jenkins-agents/rust/ocp-config/bc.yml
@@ -19,7 +19,7 @@ parameters:
 - name: RUST_VERSION
   description: "The Rust version"
   required: true
-  value: "1.94.1"
+  value: "1.96.0"
 - name: RUST_TOOLCHAIN
   description: "The Rust target toolchain"
   required: true
@@ -27,19 +27,19 @@ parameters:
 - name: CARGO_NEXTEST_VERSION
   description: "The Cargo Nextest testing framework version"
   required: true
-  value: "0.9.132"
+  value: "0.9.138"
 - name: CARGO_LLVM_COV_VERSION
   description: "The Cargo LLVM Coverage tool version"
   required: true
-  value: "0.8.5"
+  value: "0.8.7"
 - name: CARGO_GENERATE_VERSION
   description: "The Cargo Generate tool version"
   required: true
-  value: "0.23.8"
+  value: "0.23.12"
 - name: CARGO_DENY_VERSION
   description: "The Cargo Deny tool version"
   required: true
-  value: "0.19.1"
+  value: "0.19.9"
 objects:
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig

--- a/docs/modules/jenkins-agents/pages/rust.adoc
+++ b/docs/modules/jenkins-agents/pages/rust.adoc
@@ -11,7 +11,7 @@ Rust installation is managed by `rustup`, which offers a convenient way to load 
 
 And, the version defined in the `rust-toolchain` file is the one that the Jenkins Agent will use (even if it is not the default). That file MUST be in the root of the projects' repository.
 
-Default Minimum Supported Rust Version (MSRV) **1.94.1**.
+Default Minimum Supported Rust Version (MSRV) **1.96.0**.
 
 Default Rust edition in use is **2024**. See https://doc.rust-lang.org/edition-guide/introduction.html[Rust Edition Guide] for further information.
 

--- a/docs/modules/quickstarters/pages/be-rust-axum.adoc
+++ b/docs/modules/quickstarters/pages/be-rust-axum.adoc
@@ -71,7 +71,7 @@ It contains the basic setup for Docker, Jenkins, SonarQube and OpenShift.
 
 == Frameworks used
 
-* https://www.rust-lang.org/[Rust 1.94.x]
+* https://www.rust-lang.org/[Rust 1.96.x]
 * https://github.com/tokio-rs/axum[Axum 0.8.x]
 * https://nexte.st/[Nextest 0.9.x]
 * https://github.com/taiki-e/cargo-llvm-cov/[LLVM coverage 0.8.x]
@@ -231,7 +231,7 @@ which makes use of the crate `rustls`, like:
 
 ```
 [dependencies]
-sqlx = { version = "0.8", features = [ "runtime-tokio", "tls-rustls", "postgres", "uuid", "json", "chrono", "macros", "migrate" ] }
+sqlx = { version = "0.9", features = [ "runtime-tokio", "tls-rustls", "postgres", "uuid", "json", "chrono", "macros", "migrate" ] }
 ```
 
 See SQLx's https://docs.rs/sqlx/latest/sqlx/#tls-support[TLS features list support], or https://github.com/launchbadge/sqlx?tab=readme-ov-file#cargo-feature-flags[all SQLx feature flags], for further learning.


### PR DESCRIPTION
**Tooling Upgrades: Updated global and CI cargo tools to their latest stable versions.**
- Rust: Upgraded to stable version 1.96.0.
- cargo-deny: Upgraded to version 0.19.9
- cargo-nextest: Upgraded to version 0.9.138 
- cargo-llvm: Upgraded version to 0.8.7 
- cargo-generate: Upgraded version to 0.23.12

**Configuration Migration: Replaced envy with config (config-rs).**
Provides support for layered configuration with strong support for [12-factor](https://12factor.net/config) applications and offers better flexibility for complex data structures and stronger type safety.

**rust-toolchain.yaml update :**
Configures the default profile to include standard developer tooling.
Explicitly bundles rustfmt, clippy, and rust-analyzer to ensure editors (Zed, etc.) use the correct toolchain for analysis rather than falling back to system defaults.

Closes [#1162](https://github.com/opendevstack/ods-quickstarters/issues/1162)

Tasks: 
- [x ] Updated documentation in `docs/modules/...` directory
- [ ] Ran tests in `<quickstarter>/testdata` directory
